### PR TITLE
Use .iterator() to reduce memory usage in data migration

### DIFF
--- a/mapit/migrations/0006_move_geometry_area_ids.py
+++ b/mapit/migrations/0006_move_geometry_area_ids.py
@@ -8,13 +8,13 @@ from django.conf import settings
 class Migration(DataMigration):
 
     def forwards(self, orm):
-        for g in orm.Geometry.objects.all():
+        for g in orm.Geometry.objects.all().iterator():
             g.areas.add( g.area )
             g.save()
 
 
     def backwards(self, orm):
-        for g in orm.Geometry.objects.all():
+        for g in orm.Geometry.objects.all().iterator():
             g.area = g.areas.all()[0]
             g.save()
 


### PR DESCRIPTION
With all the UK data imported, this migration failed with a memory
error on a machine with 8GB of virtual memory, but it succeeded
when using .iterator() on the QuerySet. This is suggested in the
documentation for iterator, which says:

```
'For a QuerySet which returns a large number of objects,
[iterator()] often results in better performance and a
significant reduction in memory'
```

https://docs.djangoproject.com/en/1.2/ref/models/querysets/#iterator
