### PR TITLE
Enable the use of remote overpass servers instead of local one, by means of using wget. Parametrize this behaviour on a config file.

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -1,0 +1,11 @@
+# whether using local server (osm3s) or remove overpass API
+localserver=True
+# overpass API server
+overpass_server="http://overpass-api.de/api/interpreter"
+# osm3s_db directory
+osm3s_db_directory="/home/overpass/db/"
+# wget path (e.g. "/usr/bin/wget" or "c:/cygwin/bin/wget.exe"). The default value should
+# work if wget command is in the PATH
+wget_path="wget"
+
+


### PR DESCRIPTION
Enable the use of remote overpass servers instead of local one, by means of using wget. Parametrize this behaviour on a config file.

This is useful for users wishing to user your boundaries.py command but don't want to or can't setup a full overpass server
