### PR TITLE
Update OSM data license - generations > 1 have been ODbL

### DIFF
--- a/mapit/templates/global/mapit/copyright.html
+++ b/mapit/templates/global/mapit/copyright.html
@@ -1,4 +1,8 @@
 <p id="copyright">This database contains OpenStreetMap data &copy;
-<a href="http://www.openstreetmap.org/">OpenStreetMap</a> and contributors,
-<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA-2.0</a>.
+<a href="http://www.openstreetmap.org/">OpenStreetMap</a> and contributors;
+the data from generation 1 can be used under the
+<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA-2.0</a>
+license, while the data from all more recent generations can be
+used under the
+<a href="http://opendatacommons.org/licenses/odbl/1.0/">ODbL</a>.
 </p>


### PR DESCRIPTION
The license statement on MapIt Global pages still said
"CC-BY-SA-2.0", although since the first released version,
OSM data was relicensed under the ODbL.

Fixes #80
