### PR TITLE
Restore optional use of a remote Overpass server

### DIFF
--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -35,3 +35,25 @@ RATE_LIMIT:
 # Email address that errors should be sent to. Optional.
 BUGS_EMAIL: 'example@example.org'
 
+#########################################################################
+
+# You can ignore all of the settings below this point in the file
+# unless you want to use the scripts for setting up MapIt Global.
+
+# The scripts for setting up global MapIt rely on a Overpass API
+# server.  For bulk imports (e.g. setting up a instance of Global
+# MapIt) you should set up your own Overpass server locally, but for
+# generating a few KML files from OSM, it's easier to just use a
+# remote server.
+LOCAL_OVERPASS: False
+
+# If you want to use a local overpass server (i.e. LOCAL_OVERPASS is
+# True) then you should specify here the path to the database
+# directory.
+OVERPASS_DB_DIRECTORY: '/home/overpass/db/'
+
+# If you're using a remote overpass server (i.e. LOCAL_OVERPASS is
+# False) you should set its URL here. Please be aware that these
+# scripts can put a lot of load on the remote server, so set up your
+# own Overpass server for bulk imports.
+OVERPASS_SERVER: 'http://overpass-api.de/api/interpreter'


### PR DESCRIPTION
When we switched to using a local Overpass server for MapIt
Global, the option to use a remote Overpass server instead
was removed.  This restores that option, controlled by settings
in conf/general.yml (LOCAL_OVERPASS, OVERPASS_DB_DIRECTORY
and OVERPASS_SERVER.)  It's still useful to be able to use
the remote server out-of-the-box for testing, and quickly
grabbing the KML for and OSM way or relation.

Thanks to Cesar Martinez Izquierdo (@dispiste) who made a
pull request with similar functionality some time ago, but
who closed it (unmerged) later.  This commit introduces similar
changes, but using urllib2 instead of relying on wget, and
using the MapIt general.yml configuration file instead of a
new configuration module.
