### PR TITLE
Fix the invocation of get_pip.bash; raw.github.com now returns 301

### DIFF
--- a/conf/post_deploy_actions.bash
+++ b/conf/post_deploy_actions.bash
@@ -28,10 +28,10 @@ fi
 source $virtualenv_activate
 
 # Upgrade pip to a secure version
-# curl -s https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
+# curl -L -s https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
 # Revert to the line above once we can get a newer setuptools from Debian, or
 # pip ceases to need such a recent one.
-curl -s https://raw.github.com/mysociety/commonlib/master/bin/get_pip.bash | bash
+curl -L -s https://raw.github.com/mysociety/commonlib/master/bin/get_pip.bash | bash
 
 # Install all the packages
 pip install -r requirements.txt


### PR DESCRIPTION
A GET request for the URL:

  https://raw.github.com/mysociety/commonlib/master/bin/get_pip.bash

... currently returns a 301 Moved Permanently with Location:

  https://raw.githubusercontent.com/mysociety/commonlib/master/bin/get_pip.bash

However, curl won't follow redirects without -L, so zero bytes
were being piped to bash, pip wasn't being upgraded and the latest
setuptools wasn't being installed.
