### PR TITLE
Add a changelog page for MapIt UK

### DIFF
--- a/mapit/templates/gb/mapit/changelog.html
+++ b/mapit/templates/gb/mapit/changelog.html
@@ -1,0 +1,45 @@
+{% extends "mapit/base.html" %}
+
+{% block title %}Changelog{% endblock title %}
+
+{% block content %}
+
+<h2>Changelog</h2>
+<p>Changes to MapIt UK's data</p>
+
+<h3>2014-10-14 - Torfaen council changes</h3>
+
+<p>A one-off script was run to fix up some of the changes to Torfaen
+wards/communities in the May 2014 edition of Boundary-Line that should not
+have been present.</p>
+
+<p><a href="http://www.legislation.gov.uk/wsi/2013/2156/contents/made">
+http://www.legislation.gov.uk/wsi/2013/2156/contents/made</a> is the source
+for all of this. Specifically, section 2 saying that articles 5, 6 and 10
+don't come into operation until before the next election, which is 2017.</p>
+
+<p>This script revoked the changes made for the purposes of articles 5 and 6,
+but the changes for article 10 overlap with changes for (active) articles 8
+and 9, so we will live with those being incorrect until Ordnance Survey
+release hopefully fixed boundaries in October.</p>
+
+<p>Boundaries W05000993, W04000981, W05000997, W04000984, W05000995, and
+W05000996 were deleted, with W05000771, W04000761, W05000779, W04000767,
+W05000777, and W05000777 reinstated.</p>
+
+<h3>Changes and additions since 2010</h3>
+
+<ul>
+<li>22, May 2014: May 2014 Boundary-Line
+<li>21, December 2013: October 2013 Boundary-Line
+<li>20, May 2013: May 2013 Boundary-Line
+<li>19, March 2013: October 2012 Boundary-Line
+<li>18, July 2012: Northern Ireland Output Areas
+<li>17, May 2012: May 2012 Boundary-Line
+<li>16, April 2012: October 2011 Boundary-Line
+<li>15, January 2011: 2011 Scottish Parliament boundaries
+<li>14, January 2011: October 2010 Boundary-Line
+<li>13, July 2010: May 2010 Boundary-Line
+</ul>
+
+{% endblock %}

--- a/mapit/templates/mapit/index.html
+++ b/mapit/templates/mapit/index.html
@@ -112,6 +112,9 @@ to keep NUUG going.
                     <li><a href="#about-mapit">About MapIt</a></li>
                     <li><a href="#usage-licence">Usage &amp; licence</a></li>
                     <li><a href="https://github.com/mysociety/mapit">Source code</a></li>
+                    {% if country == 'GB' %}
+                    <li><a href="{% url 'mapit_changelog' %}">Changelog</a></li>
+                    {% endif %}
                 </ul>
 
             </nav>
@@ -173,7 +176,7 @@ to keep NUUG going.
             rewritten and made public for the whole UK.
 
             {% if country == 'GB' %}
-                        
+
             Versions have appeared in other countries, such as
             <a href="http://mapit.nuug.no/">Norway</a>, and in 2012 we released a
             <a href="http://global.mapit.mysociety.org/">global version</a> based on OpenStreetMap data.

--- a/mapit/urls.py
+++ b/mapit/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import patterns
+from django.conf.urls import patterns, include
+from django.conf import settings
 
 from mapit.shortcuts import render
 
@@ -44,3 +45,10 @@ urlpatterns = patterns('',
     (r'^areas$', 'mapit.views.areas.deal_with_POST', { 'call': 'areas' }),
     (r'^code/(?P<code_type>[^/]+)/(?P<code_value>[^/]+?)%s$' % format_end, 'mapit.views.areas.area_from_code'),
 )
+
+# Include app-specific urls
+if (settings.MAPIT_COUNTRY == 'GB'):
+    urlpatterns += patterns('',
+        (r'^', include('mapit_gb.urls')),
+    )
+

--- a/mapit_gb/urls.py
+++ b/mapit_gb/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import patterns
+
+from mapit.shortcuts import render
+
+urlpatterns = patterns('',
+    (r'^changelog$', render, { 'template_name': 'mapit/changelog.html' }, 'mapit_changelog' ),
+)


### PR DESCRIPTION
This PR adds a new static page in the mapit_gb app which provides a changelog
page, then puts it into the main homepage nav if the country == GB.

I've copied the style of the licensing page and added the first entry for the
recent Torfaen changes as an example, using the commit message with a few
tweaks.

Does this look reasonable?

<!---
@huboard:{"order":100.875,"milestone_order":141,"custom_state":""}
-->
