### PR TITLE
Italian application added. Minor bugs corrected.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 .venv
 
 .DS_Store
+django_mapit.egg-info

--- a/mapit_gb/templates/mapit/changelog.html
+++ b/mapit_gb/templates/mapit/changelog.html
@@ -4,14 +4,28 @@
 
 {% block content %}
 
+<h2>Current status</h2>
+<ul>
+    <li><strong>Code-Point:</strong> November 2014 edition.
+
+    <li><strong>Boundary-Line:</strong> October 2014 edition.
+
+    <li><strong>Super Output Areas:</strong> The 2001 Super Output Areas for
+    England and Wales from ONS, both full and generalised; the 2001 NI Output
+    Areas and Super Output Areas from NISRA.
+
+    <li><strong>Welsh community wards:</strong> A one-off import from October
+    2012, not updated since.
+
+</ul>
+
 <h2>Changelog</h2>
-<p>Changes to MapIt UK's data</p>
+<p>Changes to MapIt UK’s data</p>
 
 <h3>2014-12-05 - October 2014 Boundary-Line import</h3>
 
 <em>Generation 23</em>, containing the import of the October 2014
-Boundary-Line. This edition reverted all the Torfaen changes from May 2014, not
-just articles 5, 6 and 10, and so we have revoked those additional changes too,
+Boundary-Line. This edition reverted all the Torfaen changes from May 2014,
 returning the Torfaen communities and electoral districts to as they were in
 the October 2013 edition.
 

--- a/mapit_it/countries.py
+++ b/mapit_it/countries.py
@@ -4,7 +4,6 @@ __author__ = 'guglielmo'
 # SRID to also output area geometry information in
 area_geometry_srid = 32632
 
-
 # Italian postcodes are five digits.
 def is_valid_postcode(pc):
     if re.match('\d{5}$', pc):

--- a/mapit_it/management/commands/mapit_IT_find_parents.py
+++ b/mapit_it/management/commands/mapit_IT_find_parents.py
@@ -11,3 +11,4 @@ class Command(FindParentsCommand):
         # A Province's parent is a Regione:
         'PRO': 'REG',
     }
+


### PR DESCRIPTION
I've installed mapit, using the git URL in the requirements as a django application within a pre-existing project.
I modified the .gitignore to include the ``django_mapit.egg-info`` path, automatically created.

The mapit_it application has been added, with a management task to find parents of the official ISTAT administrative subdivisions and an adapted zip code validation. It is just a prototype and other functions and tasks will follow soon.

Two minor bugs require revision, but I could not make separate pull requests (sorry)

  - 2bb188e - a string emitted to stdout as log was causing a unicode error (django 1.6.8 over python 2.7.7)
  - f7dde4c - cache value injection in a new key was cast to int; the string caused an error to the following incr instruction (cache engine is LocMem, while development)


<!---
@huboard:{"order":135.5,"milestone_order":147,"custom_state":""}
-->
