### PR TITLE
Use "CREATE EXTENSION postgis; ..." on Ubuntu trusty

### DIFF
--- a/bin/install-as-user
+++ b/bin/install-as-user
@@ -68,7 +68,19 @@ fi
 echo -n "Setting up database... "
 if ! psql -l | egrep "^ *$DB_NAME *\|" > /dev/null
 then
-    createdb -T template_postgis --owner "$UNIX_USER" "$DB_NAME"
+    if [ trusty = "$(lsb_release -s -c)" ]
+    then
+        # Currently the only supported distribution where we can just
+        # use CREATE EXTENSION to make this a PostGIS database is on
+        # Ubuntu trusty:
+        createdb --owner "$UNIX_USER" "$DB_NAME"
+        COMMAND="CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;"
+        psql -c "$COMMAND" "$DB_NAME"
+    else
+        # Otherwise, the template_postgis template should already
+        # have been created.
+        createdb -T template_postgis --owner "$UNIX_USER" "$DB_NAME"
+    fi
 fi
 
 conf/post_deploy_actions.bash

--- a/bin/site-specific-install.sh
+++ b/bin/site-specific-install.sh
@@ -31,11 +31,24 @@ install_website_packages
 
 install_postgis
 
-add_postgresql_user
+if [ x"$DISTRIBUTION" = x"ubuntu" ] && [ x"$DISTVERSION" = x"trusty" ]
+then
+    # On trusty, the database user will need to be a superuser so that
+    # it can create the PostGIS extension; we'll drop that privilege
+    # afterwards:
+    add_postgresql_user --superuser
+else
+    add_postgresql_user
+fi
 
 make_log_directory
 
 su -l -c "$REPOSITORY/bin/install-as-user '$UNIX_USER' '$HOST' '$DIRECTORY'" "$UNIX_USER"
+
+if [ x"$DISTRIBUTION" = x"ubuntu" ] && [ x"$DISTVERSION" = x"trusty" ]
+then
+    sudo -u postgres psql -c "ALTER USER $UNIX_USER WITH NOSUPERUSER"
+fi
 
 install_sysvinit_script
 


### PR DESCRIPTION
As described here:

  https://docs.djangoproject.com/en/1.6/ref/contrib/gis/install/postgis/#creating-a-spatial-database-with-postgis-2-0-and-postgresql-9-1

... creating a PostGIS database should be done with
"CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;"
where PostGIS and PostgreSQL are late enough versions, rather
than the script to create a template_postgis template.

The only supported distribution where we have these versions is
currently Ubuntu trusty.