### PR TITLE
Stream JSON responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,5 +51,6 @@ before_script:
   - "echo 'MAPIT_DB_NAME: mapit' > conf/general.yml"
   - "echo 'MAPIT_DB_USER: postgres' >> conf/general.yml"
   - "echo 'DJANGO_SECRET_KEY: secret' >> conf/general.yml"
+  - "echo 'COUNTRY: GB' >> conf/general.yml"
 script:
-  - python -Wall manage.py test mapit
+  - python -Wall manage.py test mapit mapit_gb

--- a/mapit/iterables.py
+++ b/mapit/iterables.py
@@ -1,3 +1,14 @@
+def defaultiter(it, default):
+    """This wraps an iterable so that if it's empty,
+    it will return a default value instead."""
+    empty = True
+    for i in it:
+        yield i
+        empty = False
+    if empty:
+        yield default
+
+
 # If you wanted iterdict() to be more generic, it'd be something like:
 # from django.utils import six
 # import itertools

--- a/mapit/iterables.py
+++ b/mapit/iterables.py
@@ -1,0 +1,49 @@
+# If you wanted iterdict() to be more generic, it'd be something like:
+# from django.utils import six
+# import itertools
+# if not args:
+#     self.ITERABLE = iter()
+# elif isinstance(args[0], dict):
+#     self.ITERABLE = six.iteritems(args[0])
+# else:
+#     self.ITERABLE = args[0]
+# if kwargs:
+#     self.ITERABLE = itertools.chain(self.ITERABLE, six.iteritems(kwargs))
+
+
+class iterdict(dict):
+    """This is a fake dict that sticks an iterable on items/iteritems. Why on
+    earth would you want to do such a thing, I hear you cry? Well, if you want
+    to output what you'd like to be a dict of c. 200,000 objects from a
+    database, currently held in a lovely iterable, as JSON, but discover that
+    json.iterencode() doesn't work with iterators, and that wouldn't be much
+    help with a dict anyway, you either need to write your own iterator to
+    output a JSON object, or trick iterencode() into thinking you're passing it
+    a dict when you're not."""
+
+    def __init__(self, *args, **kwargs):
+        self.ITERABLE = args[0]
+        # Create a dict so that "if X" passes.
+        super(iterdict, self).__init__({'Hack': True})
+
+    def iteritems(self):
+        return self.ITERABLE
+
+    def items(self):
+        return self.ITERABLE
+
+
+class iterlist(list):
+    """This is a fake list that uses its own stored iterable. The built in json
+    package, though it can work as an iterator using iterencode() or indeed
+    dump(), can't take one as input, which is annoying if you're trying to save
+    memory. This class can be passed to iterencode() and will work the same as
+    a list, but won't require the list to exist first."""
+
+    def __init__(self, l):
+        self.ITERABLE = l
+        # Create a list so that "if X" passes.
+        super(iterlist, self).__init__("Hack")
+
+    def __iter__(self):
+        return self.ITERABLE

--- a/mapit/middleware/gzip.py
+++ b/mapit/middleware/gzip.py
@@ -1,0 +1,79 @@
+"""
+A copy of Django's gzip middleware, adjusted for 1.4 and
+https://code.djangoproject.com/ticket/24242 by including changed
+compress_sequence/StreamingBuffer.
+"""
+from __future__ import absolute_import
+
+import re
+
+from django.utils.text import compress_string, StreamingBuffer as DjangoStreamingBuffer
+from django.utils.cache import patch_vary_headers
+from gzip import GzipFile
+
+re_accepts_gzip = re.compile(r'\bgzip\b')
+
+
+class StreamingBuffer(DjangoStreamingBuffer):
+    def read(self):
+        if not self.vals:
+            return b''
+        ret = b''.join(self.vals)
+        self.vals = []
+        return ret
+
+
+# Like compress_string, but for iterators of strings.
+def compress_sequence(sequence):
+    buf = StreamingBuffer()
+    zfile = GzipFile(mode='wb', compresslevel=6, fileobj=buf)
+    # Output headers...
+    yield buf.read()
+    for item in sequence:
+        zfile.write(item)
+        data = buf.read()
+        if data:
+            yield data
+    zfile.close()
+    yield buf.read()
+
+
+class GZipMiddleware(object):
+    """
+    This middleware compresses content if the browser allows gzip compression.
+    It sets the Vary header accordingly, so that caches will base their storage
+    on the Accept-Encoding header.
+    """
+    def process_response(self, request, response):
+        # It's not worth attempting to compress really short responses.
+        if not getattr(response, 'streaming', None) and len(response.content) < 200:
+            return response
+
+        # Avoid gzipping if we've already got a content-encoding.
+        if response.has_header('Content-Encoding'):
+            return response
+
+        patch_vary_headers(response, ('Accept-Encoding',))
+
+        ae = request.META.get('HTTP_ACCEPT_ENCODING', '')
+        if not re_accepts_gzip.search(ae):
+            return response
+
+        if getattr(response, 'streaming', None):
+            # Delete the `Content-Length` header for streaming content, because
+            # we won't know the compressed size until we stream it.
+            response.streaming_content = compress_sequence(response.streaming_content)
+            del response['Content-Length']
+        else:
+            # Return the compressed content only if it's actually shorter.
+            compressed_content = compress_string(response.content)
+            if len(compressed_content) >= len(response.content):
+                return response
+            response.content = compressed_content
+            response['Content-Length'] = str(len(response.content))
+
+        if response.has_header('ETag'):
+            response['ETag'] = re.sub('"$', ';gzip"', response['ETag'])
+        response['Content-Encoding'] = 'gzip'
+
+        return response

--- a/mapit/models.py
+++ b/mapit/models.py
@@ -242,12 +242,16 @@ class Area(models.Model):
 
     @property
     def all_codes(self):
-        if not getattr(self, 'code_list', None):
-            self.code_list = self.codes.select_related('type')
-        codes = {}
-        for code in self.code_list:
-            codes[code.type.code] = code.code
-        return codes
+        if not hasattr(self, '_all_codes'):
+            code_list = self.codes.select_related('type')
+            self._all_codes = {}
+            for code in code_list:
+                self._all_codes[code.type.code] = code.code
+        return self._all_codes
+
+    @all_codes.setter
+    def all_codes(self, value):
+        self._all_codes = value
 
     def __str__(self):
         name = self.name or '(unknown)'

--- a/mapit/shortcuts.py
+++ b/mapit/shortcuts.py
@@ -40,18 +40,12 @@ def render(request, template_name, context=None):
     )
 
 
-def sorted_areas(areas):
-    # In here to prevent a circular dependency
-    from mapit import countries
-    if hasattr(countries, 'sorted_areas'):
-        return countries.sorted_areas(areas)
-    return list(areas)
 
 
 def output_html(request, title, areas, **kwargs):
     kwargs['json_url'] = request.get_full_path().replace('.html', '')
     kwargs['title'] = title
-    kwargs['areas'] = sorted_areas(areas)
+    kwargs['areas'] = areas
     kwargs['indent_areas'] = kwargs.get('indent_areas', False)
     return render(request, 'mapit/data.html', kwargs)
 

--- a/mapit/shortcuts.py
+++ b/mapit/shortcuts.py
@@ -1,13 +1,18 @@
+import itertools
 import json
+
 import django
 from django import http
 from django.db import connection
 from django.conf import settings
 from django.shortcuts import get_object_or_404 as orig_get_object_or_404
 from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.template import loader, RequestContext, Context
 from django.utils.six.moves import map
 from django.utils.encoding import smart_str
+from django.utils.translation import ugettext as _
+
+from mapit.iterables import defaultiter
 
 from django.core.serializers.json import DjangoJSONEncoder
 # Assuming at least python 2.6, in Django < 1.6, the above class is either a
@@ -35,21 +40,32 @@ class GEOS_JSONEncoder(DjangoJSONEncoder):
 def render(request, template_name, context=None):
     if context is None:
         context = {}
-#    context['base'] = base or 'base.html'
-#    context['connection'] = connection
     return render_to_response(
         template_name, context, context_instance=RequestContext(request)
     )
 
 
-
-
 def output_html(request, title, areas, **kwargs):
     kwargs['json_url'] = request.get_full_path().replace('.html', '')
     kwargs['title'] = title
-    kwargs['areas'] = areas
-    kwargs['indent_areas'] = kwargs.get('indent_areas', False)
-    return render(request, 'mapit/data.html', kwargs)
+    tpl = loader.render_to_string('mapit/data.html', kwargs, context_instance=RequestContext(request))
+    wraps = tpl.split('!!!DATA!!!')
+
+    indent_areas = kwargs.get('indent_areas', False)
+    item_tpl = loader.get_template('mapit/areas_item.html')
+    areas = map(lambda area: item_tpl.render(Context({'area': area, 'indent_areas': indent_areas})), areas)
+    areas = defaultiter(areas, '<li>' + _('No matching areas found.') + '</li>')
+    content = itertools.chain(wraps[0:1], areas, wraps[1:])
+    content = map(smart_str, content)  # Workaround Django bug #24240
+
+    if django.get_version() >= '1.5':
+        response_type = http.StreamingHttpResponse
+    else:
+        response_type = http.HttpResponse
+        # Django 1.4 middleware messes up iterable content
+        content = list(content)
+
+    return response_type(content)
 
 
 def output_json(out, code=200):

--- a/mapit/shortcuts.py
+++ b/mapit/shortcuts.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from django.shortcuts import get_object_or_404 as orig_get_object_or_404
 from django.shortcuts import render_to_response
 from django.template import RequestContext
+from django.utils.six.moves import map
+from django.utils.encoding import smart_str
 
 from django.core.serializers.json import DjangoJSONEncoder
 # Assuming at least python 2.6, in Django < 1.6, the above class is either a
@@ -60,6 +62,7 @@ def output_json(out, code=200):
         indent = 4
     encoder = GEOS_JSONEncoder(ensure_ascii=False, indent=indent)
     content = encoder.iterencode(out)
+    content = map(smart_str, content)  # Workaround Django bug #24240
 
     types = {
         400: http.HttpResponseBadRequest,

--- a/mapit/templates/mapit/areas.html
+++ b/mapit/templates/mapit/areas.html
@@ -1,20 +1,7 @@
-{% load url from future %}
 <ol class="area_list">
 {% for area in areas %}
-    {% if indent_areas %}
-    <li class="{{ area.css_indent_class }}">
-    {% else %}
-    <li>
-    {% endif %}
-        <h3><a href="{% url "mapit_index" %}area/{{ area.id }}.html">{{ area.name }}</a></h3>
-        <p>ID {{ area.id }}, {{ area.type.description }}
-            <small>({{ area.type.code }})</small>, {{ area.country }}</p>
-        {% if area.parent_area %}
-        <p>A child of <a href="{% url "mapit_index" %}area/{{ area.parent_area.id }}.html">{{ area.parent_area.name }}</a></p>
-        {% endif %}
-    </li>
+    {% include "mapit/areas_item.html" %}
 {% empty %}
     <li>No matching areas found.</li>
 {% endfor %}
 </ol>
-

--- a/mapit/templates/mapit/areas_item.html
+++ b/mapit/templates/mapit/areas_item.html
@@ -1,0 +1,9 @@
+{% load url from future %}
+<li{% if indent_areas %} class="{{ area.css_indent_class }}"{% endif %}>
+    <h3><a href="{% url "mapit_index" %}area/{{ area.id }}.html">{{ area.name }}</a></h3>
+    <p>ID {{ area.id }}, {{ area.type.description }}
+        <small>({{ area.type.code }})</small>, {{ area.country }}</p>
+    {% if area.parent_area %}
+    <p>A child of <a href="{% url "mapit_index" %}area/{{ area.parent_area.id }}.html">{{ area.parent_area.name }}</a></p>
+    {% endif %}
+</li>

--- a/mapit/templates/mapit/data.html
+++ b/mapit/templates/mapit/data.html
@@ -8,6 +8,8 @@
 
 <p>Get <a href="{{ json_url }}">this data as JSON</a></p>
 
-{% include "mapit/areas.html" %}
+<ol class="area_list">
+    !!!DATA!!!
+</ol>
 
 {% endblock %}

--- a/mapit/tests/test_middleware.py
+++ b/mapit/tests/test_middleware.py
@@ -1,6 +1,9 @@
+from unittest import skipIf
+
+import django
 from django.test import TestCase
 from django.test.client import RequestFactory
-from django.http import HttpResponse, HttpResponsePermanentRedirect
+from django import http
 
 from ..middleware import JSONPMiddleware
 
@@ -13,30 +16,37 @@ class JSONPMiddlewareTest(TestCase):
 
     def test_process_response_ignores_302_redirects(self):
         request = self.factory.get("/dummy_url", {"callback": "xyz"})
-        response = HttpResponsePermanentRedirect("/new_url")
+        response = http.HttpResponsePermanentRedirect("/new_url")
         middleware_response = self.middleware.process_response(request, response)
         self.assertEqual(middleware_response, response)
 
     def test_process_response_uses_callback(self):
         request = self.factory.get("/dummy_url", {"callback": "xyz"})
-        response = HttpResponse(content="blah")
+        response = http.HttpResponse(content="blah")
         middleware_response = self.middleware.process_response(request, response)
         self.assertEqual(middleware_response.content, b"typeof xyz === 'function' && xyz(blah)")
 
+    @skipIf(django.get_version() < '1.5', 'not supported in this version')
+    def test_process_response_uses_callback_streaming(self):
+        request = self.factory.get("/dummy_url", {"callback": "xyz"})
+        response = http.StreamingHttpResponse("blah")
+        middleware_response = self.middleware.process_response(request, response)
+        self.assertEqual(b''.join(middleware_response.streaming_content), b"typeof xyz === 'function' && xyz(blah)")
+
     def test_process_response_uses_ignores_requests_without_callback(self):
         request = self.factory.get("/dummy_url")
-        response = HttpResponse(content="blah")
+        response = http.HttpResponse(content="blah")
         middleware_response = self.middleware.process_response(request, response)
         self.assertEqual(middleware_response, response)
 
     def test_process_response_callback_allowed_characters(self):
         request = self.factory.get("/dummy_url", {"callback": "xyz123_$."})
-        response = HttpResponse(content="blah")
+        response = http.HttpResponse(content="blah")
         middleware_response = self.middleware.process_response(request, response)
         self.assertEqual(middleware_response.content, b"typeof xyz123_$. === 'function' && xyz123_$.(blah)")
 
         # Try with a character not allowed in the callback
         request = self.factory.get("/dummy_url", {"callback": "xyz123_$.["})
-        response = HttpResponse(content="blah")
+        response = http.HttpResponse(content="blah")
         middleware_response = self.middleware.process_response(request, response)
         self.assertEqual(middleware_response, response)

--- a/mapit/tests/test_views.py
+++ b/mapit/tests/test_views.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.contrib.gis.geos import Polygon, Point
 
 from mapit.models import Type, Area, Geometry, Generation, Postcode
+from mapit.tests.utils import get_content
 
 
 class AreaViewsTest(TestCase):
@@ -71,7 +72,7 @@ class AreaViewsTest(TestCase):
         url = '/point/4326/-3.4,51.5.json'
         response = self.client.get(url)
 
-        content = json.loads(response.content.decode('utf-8'))
+        content = get_content(response)
 
         self.assertEqual(
             set((int(x) for x in content.keys())),
@@ -92,7 +93,7 @@ class AreaViewsTest(TestCase):
         id = self.small_area_1.id
         url = '/area/%d/example_postcode' % id
         response = self.client.get(url)
-        content = json.loads(response.content.decode('utf-8'))
+        content = get_content(response)
         self.assertEqual(content, self.postcode.postcode)
 
     def test_nearest_with_bad_srid(self):
@@ -100,4 +101,6 @@ class AreaViewsTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
         content = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(content, {'code': 400, 'error': 'GetProj4StringSPI: Cannot find SRID (84) in spatial_ref_sys\n'})
+        self.assertEqual(content, {
+            'code': 400, 'error': 'GetProj4StringSPI: Cannot find SRID (84) in spatial_ref_sys\n'
+        })

--- a/mapit/tests/utils.py
+++ b/mapit/tests/utils.py
@@ -1,0 +1,10 @@
+import json
+
+
+def get_content(response):
+    if getattr(response, 'streaming', None):
+        content = b''.join(response.streaming_content)
+    else:
+        content = response.content
+    content = json.loads(content.decode('utf-8'))
+    return content

--- a/mapit/views/areas.py
+++ b/mapit/views/areas.py
@@ -25,13 +25,13 @@ def add_codes(areas):
     codes = Code.objects.select_related('type').filter(area__in=areas)
     lookup = {}
     for code in codes:
-        lookup.setdefault(code.area_id, []).append(code)
+        lookup.setdefault(code.area_id, {})[code.type.code] = code.code
     if isinstance(areas, QuerySet):
         if hasattr(countries, 'sorted_areas'):
             areas = countries.sorted_areas(areas)
     for area in areas:
         if area.id in lookup:
-            area.code_list = lookup[area.id]
+            area.all_codes = lookup[area.id]
     return areas
 
 

--- a/mapit/views/areas.py
+++ b/mapit/views/areas.py
@@ -26,6 +26,9 @@ def add_codes(areas):
     lookup = {}
     for code in codes:
         lookup.setdefault(code.area_id, []).append(code)
+    if isinstance(areas, QuerySet):
+        if hasattr(countries, 'sorted_areas'):
+            areas = countries.sorted_areas(areas)
     for area in areas:
         if area.id in lookup:
             area.code_list = lookup[area.id]

--- a/mapit/views/postcodes.py
+++ b/mapit/views/postcodes.py
@@ -51,7 +51,7 @@ def postcode(request, postcode, format=None):
     except:
         generation = Generation.objects.current()
     if not hasattr(countries, 'is_special_postcode') or not countries.is_special_postcode(postcode.postcode):
-        areas = add_codes(Area.objects.by_postcode(postcode, generation))
+        areas = list(add_codes(Area.objects.by_postcode(postcode, generation)))
     else:
         areas = []
 

--- a/mapit_gb/tests.py
+++ b/mapit_gb/tests.py
@@ -42,6 +42,16 @@ class GBViewsTest(TestCase):
             generation_high=self.generation,
         )
 
+        code_type = models.CodeType.objects.create(
+            code='CodeType',
+            description='CodeType description',
+        )
+        models.Code.objects.create(
+            area=self.area,
+            type=code_type,
+            code='CODE',
+        )
+
         polygon = Polygon(((-5, 50), (-5, 55), (1, 55), (1, 50), (-5, 50)), srid=4326)
         polygon.transform(settings.MAPIT_AREA_SRID)
         self.shape = models.Geometry.objects.create(
@@ -74,7 +84,9 @@ class GBViewsTest(TestCase):
                     'generation_high': self.generation.id,
                     'country': '',
                     'country_name': '-',
-                    'codes': {},
+                    'codes': {
+                        'CodeType': 'CODE',
+                    },
                     'all_names': {},
                 }
             }

--- a/mapit_gb/tests.py
+++ b/mapit_gb/tests.py
@@ -1,5 +1,3 @@
-import json
-
 from django.conf import settings
 from django.test import TestCase
 from django.contrib.gis.geos import Polygon, Point
@@ -8,6 +6,7 @@ from django.utils.six.moves import urllib
 from mapit import utils, models
 
 from mapit_gb import countries
+from mapit.tests.utils import get_content
 
 
 def url_postcode(pc):
@@ -62,7 +61,7 @@ class GBViewsTest(TestCase):
         pc = self.postcode.postcode
         url = '/postcode/%s' % urllib.parse.quote(pc)
         response = self.client.get(url)
-        content = json.loads(response.content.decode('utf-8'))
+        content = get_content(response)
 
         in_gb_coords = self.postcode.location.transform(27700, clone=True)
         pc = countries.get_postcode_display(self.postcode.postcode)
@@ -101,7 +100,7 @@ class GBViewsTest(TestCase):
     def test_partial_json(self):
         url = '/postcode/partial/SW1A'
         response = self.client.get(url)
-        content = json.loads(response.content.decode('utf-8'))
+        content = get_content(response)
         countries.get_postcode_display(self.postcode.postcode)
         in_gb_coords = self.postcode.location.transform(27700, clone=True)
         self.assertDictEqual(content, {
@@ -121,7 +120,7 @@ class GBViewsTest(TestCase):
     def test_nearest_json(self):
         url = '/nearest/4326/%f,%f' % self.postcode.location.coords
         response = self.client.get(url)
-        content = json.loads(response.content.decode('utf-8'))
+        content = get_content(response)
         pc = countries.get_postcode_display(self.postcode.postcode)
         in_gb_coords = self.postcode.location.transform(27700, clone=True)
         self.assertDictEqual(content, {

--- a/mapit_global/countries.py
+++ b/mapit_global/countries.py
@@ -1,2 +1,2 @@
 def sorted_areas(areas):
-    return sorted(list(areas), key=lambda a: (a.type.code, a.name))
+    return areas.order_by('type__code', 'name')

--- a/project/settings.py
+++ b/project/settings.py
@@ -153,8 +153,10 @@ STATICFILES_FINDERS = (
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
+    ('django.template.loaders.cached.Loader', (
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    )),
 )
 
 # UpdateCacheMiddleware does ETag setting, and

--- a/project/settings.py
+++ b/project/settings.py
@@ -164,7 +164,8 @@ TEMPLATE_LOADERS = (
 USE_ETAGS = False
 
 MIDDLEWARE_CLASSES = (
-    'django.middleware.gzip.GZipMiddleware',
+    'mapit.middleware.gzip.GZipMiddleware',
+    # Not 'django.middleware.gzip.GZipMiddleware' to work around Django #24242
     'django.middleware.http.ConditionalGetMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
When we start, we have an iterable `QuerySet`. So this changes `add_codes` to be iterable, passes an `iterdict` [1] rather than a `dict` to `output_json`, changes `output_json` to use a `StreamingHttpResponse` by default, and updates the callback middleware to work with streaming or non-streaming responses. This hopefully reduces memory usage for one particular request from c. 2Gb to 200Mb. Similarly for `output_html`, we keep everything as an iterable, doing something horrible with a template in order to put our iteration in the middle.

[1] An `iterdict` is a `dict` subclass that does nothing but provide an iterable for `items`/`iteritems`, in order so that the `json` package will think it's a dictionary, iterate over it and output an iterator. Otherwise we'd need to load everything into a dictionary in memory to iterate it all back out...