### PR TITLE
Add country-specific templates to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,11 @@
 include LICENSE.txt README.rst
 recursive-include project *.py
-recursive-include mapit *.html *.json *.sql 
+recursive-include mapit *.html *.json *.sql
 recursive-include mapit/static *
 recursive-include data *.csv *.sql
+recursive-include mapit_gb *.html *.json *.sql
+recursive-include mapit_no *.html *.json *.sql
+recursive-include mapit_it *.html *.json *.sql
+recursive-include mapit_za *.html *.json *.sql
+recursive-include mapit_global *.html *.json *.sql
 

--- a/mapit_gb/templates/mapit/api/area-example-related.html
+++ b/mapit_gb/templates/mapit/api/area-example-related.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Examples:</dt>
 <dd>
 <ul>

--- a/mapit_gb/templates/mapit/api/area-example.html
+++ b/mapit_gb/templates/mapit/api/area-example.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Examples:</dt>
 <dd>
 <ul>

--- a/mapit_gb/templates/mapit/api/areas-examples.html
+++ b/mapit_gb/templates/mapit/api/areas-examples.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Examples:</dt>
 <dd>
     <ul>

--- a/mapit_gb/templates/mapit/api/point-example-nearest.html
+++ b/mapit_gb/templates/mapit/api/point-example-nearest.html
@@ -1,3 +1,3 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Example</dt>
 <dd><a href="{% url "mapit_index" %}nearest/27700/400000,300000.html">Example of postcode nearest to (400000,300000)</a>.</dd>

--- a/mapit_gb/templates/mapit/api/point-example.html
+++ b/mapit_gb/templates/mapit/api/point-example.html
@@ -1,3 +1,3 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Example:</dt>
 <dd><a href="{% url "mapit_index" %}point/27700/400000,300000.html">Example of areas containing (400000,300000)</a>.</dd>

--- a/mapit_gb/templates/mapit/api/postcode-example-partial.html
+++ b/mapit_gb/templates/mapit/api/postcode-example-partial.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Example:</dt>
 <dd>
     <ul>

--- a/mapit_gb/templates/mapit/api/postcode-example.html
+++ b/mapit_gb/templates/mapit/api/postcode-example.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Example:</dt>
 <dd>
     <p>If your postcode was <em>SW1A 1AA</em> you would load

--- a/mapit_global/templates/mapit/api/area-example-related.html
+++ b/mapit_global/templates/mapit/api/area-example-related.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Examples:</dt>
 <dd>
 <ul>

--- a/mapit_global/templates/mapit/api/area-example.html
+++ b/mapit_global/templates/mapit/api/area-example.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Examples:</dt>
 <ul>
     <li>Information held on Paris:

--- a/mapit_global/templates/mapit/api/areas-examples.html
+++ b/mapit_global/templates/mapit/api/areas-examples.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Examples:</dt>
 <dd>
     <ul>

--- a/mapit_global/templates/mapit/api/point-example-nearest.html
+++ b/mapit_global/templates/mapit/api/point-example-nearest.html
@@ -1,3 +1,3 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Example</dt>
 <dd><a href="{% url "mapit_index" %}nearest/4326/8.55,47.366667.html">Example of postcode nearest to (47.366667,8.55)</a>.</dd>

--- a/mapit_global/templates/mapit/api/point-example.html
+++ b/mapit_global/templates/mapit/api/point-example.html
@@ -1,3 +1,3 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Example:</dt>
 <dd><a href="{% url "mapit_index" %}point/4326/8.55,47.366667.html">Example of areas containing (47.366667,8.55)</a>.</dd>

--- a/mapit_no/templates/mapit/api/area-example-related.html
+++ b/mapit_no/templates/mapit/api/area-example-related.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Examples:</dt>
 <dd>
 <ul>

--- a/mapit_no/templates/mapit/api/area-example.html
+++ b/mapit_no/templates/mapit/api/area-example.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Examples:</dt>
 <dd>
 <ul>

--- a/mapit_no/templates/mapit/api/areas-examples.html
+++ b/mapit_no/templates/mapit/api/areas-examples.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Examples:</dt>
 <dd>
     <ul>

--- a/mapit_no/templates/mapit/api/point-example-nearest.html
+++ b/mapit_no/templates/mapit/api/point-example-nearest.html
@@ -1,3 +1,3 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Example</dt>
 <dd><a href="{% url "mapit_index" %}nearest/4326/10,59.html">Example of postcode nearest to (59,10)</a>.</dd>

--- a/mapit_no/templates/mapit/api/point-example.html
+++ b/mapit_no/templates/mapit/api/point-example.html
@@ -1,3 +1,3 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Example:</dt>
 <dd><a href="{% url "mapit_index" %}point/4326/10,59.html">Example of areas containing (59,10)</a>.</dd>

--- a/mapit_no/templates/mapit/api/postcode-example-partial.html
+++ b/mapit_no/templates/mapit/api/postcode-example-partial.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Example:</dt>
 <dd>
     <ul>

--- a/mapit_no/templates/mapit/api/postcode-example.html
+++ b/mapit_no/templates/mapit/api/postcode-example.html
@@ -1,4 +1,4 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Example:</dt>
 <dd>
     <p>If your postcode was <em>0373</em> you would load

--- a/mapit_za/templates/mapit/api/point-example.html
+++ b/mapit_za/templates/mapit/api/point-example.html
@@ -1,3 +1,3 @@
-{% load url from future %}
+{% load url from compat %}
 <dt>Example:</dt>
 <dd><a href="{% url "mapit_index" %}point/4326/18.42,-33.92.html">Example of areas containing (18.42,-33.92)</a>.</dd>


### PR DESCRIPTION
These were left out of the package by mistake, meaning you couldn't
use them from a different project when you installed django-mapit,
which is a shame.

This adds recursive-include statements for all of the current country apps.