### PR TITLE
Contact tweaks

### DIFF
--- a/mapit/templates/mapit/licensing.html
+++ b/mapit/templates/mapit/licensing.html
@@ -4,6 +4,10 @@
 
 {% block content %}
 
+<h2>Technical queries</h2>
+
+<p>Questions about how MapIt works, or the data? Drop a line to <a href="mailto:mapit&#64;mysociety.org">mapit&#64;mysociety.org</a>.</p>
+
 <h2>Usage and licensing</h2>
 
 <p>This service is free of charge for non-profit low volume use. &lsquo;Non-profit
@@ -11,8 +15,7 @@ low volume use&rsquo; means use by registered UK charities or individuals workin
 unpaid on a non-profit project, and that does not exceed 50,000 calls a year.
 Please attribute us with the text “Powered by Mapit” and a link back to the MapIt
 front page. If you are using the API for a charitable purpose and are unsure of the
-likely volume please contact us in advance by emailing
-<a href="mailto:enquiries&#64;mysociety.org">enquiries&#64;mysociety.org</a>.</p>
+likely volume please contact us in advance.</p>
 
 <p>All other users need to get a licence. We have a range of pricing options
 depending on the volumes you expect. Our licences cover 12 months, and we offer

--- a/mapit_gb/templates/mapit/index-usage.html
+++ b/mapit_gb/templates/mapit/index-usage.html
@@ -6,11 +6,7 @@
 service to be used free of charge by other registered charities, or
 individuals working unpaid on non-profit projects. The free usage
 limit for non-profit users is 50,000 calls to the API per year. All
-other uses need to acquire a licence.</p>
-
-<p><a href="/licensing">Find out if you need a licence</a> or <a
-    href="mailto:enquiries&#64;mysociety.org">get in touch</a> so we
-can discuss how we can provide you with the service you require.</p>
+other uses need to <a href="/licensing">acquire a licence</a>.</p>
 
 <p>To maintain quality of service for our own websites, as well as our
 API users, this service is rate limited to an average of 1 call per

--- a/mapit_gb/templates/mapit/intro.html
+++ b/mapit_gb/templates/mapit/intro.html
@@ -8,5 +8,4 @@ the shapes of all those boundaries.</p>
 <a href="/licensing">read more</a>.<br>You can
 <a href="https://github.com/mysociety/mapit">download the source
 on Github</a>.<br>Need a licence?
-<a href="/licensing">Read more</a> or
-<a href="mailto:enquiries&#64;mysociety.org">get in touch</a>.</p>
+<a href="/licensing">Read more</a>.</p>

--- a/mapit_global/templates/mapit/index-usage.html
+++ b/mapit_global/templates/mapit/index-usage.html
@@ -6,11 +6,11 @@
 service to be used free of charge by other registered charities, or
 individuals working unpaid on non-profit projects. The free usage
 limit for non-profit users is 50,000 calls to the API per year. All
-other uses need to acquire a licence.</p>
+other uses need to <a href="/licensing">acquire a licence</a>.</p>
 
-<p><a href="/licensing">Find out if you need a licence</a> or <a
-    href="mailto:enquiries&#64;mysociety.org">get in touch</a> so we
-can discuss how we can provide you with the service you require.</p>
+<p>To maintain quality of service for our own websites, as well as our
+API users, this service is rate limited to an average of 1 call per
+second in a rolling 3 minute period.</p>
 
 <p>To maintain quality of service for our own websites, as well as our
 API users, this service is rate limited to an average of 1 call per

--- a/mapit_global/templates/mapit/intro.html
+++ b/mapit_global/templates/mapit/intro.html
@@ -17,5 +17,4 @@ boundaries.
 <a href="/licensing">read more</a>.<br>You can
 <a href="https://github.com/mysociety/mapit">download the source
 on Github</a>.<br>Need a licence?
-<a href="/licensing">Read more</a> or
-<a href="mailto:enquiries&#64;mysociety.org">get in touch</a>.</p>
+<a href="/licensing">Read more</a>.</p>

--- a/mapit_za/templates/mapit/index-usage.html
+++ b/mapit_za/templates/mapit/index-usage.html
@@ -5,11 +5,7 @@
     service to be used free of charge by other registered charities, or
     individuals working unpaid on non-profit projects. The free usage
     limit for non-profit users is 50,000 calls to the API per year. All
-    other uses need to acquire a licence.</p>
-
-    <p><a href="/licensing">Find out if you need a licence</a> or <a
-        href="mailto:enquiries&#64;mysociety.org">get in touch</a> so we
-    can discuss how we can provide you with the service you require.</p>
+    other uses need to <a href="/licensing">acquire a licence</a>.</p>
 
     <p>To maintain quality of service for our own websites, as well as our
     API users, this service is rate limited to an average of 1 call per


### PR DESCRIPTION
The enquiries@ address gets quite a bit of what might be described as "tech support". This PR:

a) adds a contact address (mapit@) for technical queries

b) attempts to make there be only one place where the contact email addresses appear, so that changing them isn't quite so involved next time; hopefully I caught all the other places.