### PR TITLE
Include same details in .geojson as in .json

### DIFF
--- a/mapit/models.py
+++ b/mapit/models.py
@@ -381,12 +381,29 @@ class Area(models.Model):
         polygons = polygons or self.polygons.all().collect()
         out = {
             'type': 'Feature',
+            'properties': self.as_dict(),
+            'geometry': json.loads(polygons.geojson),
+        }
+
+        if srid:
+            out['crs'] = {
+                'type': 'name',
+                'properties': {'name': 'EPSG:%d' % srid},
+            }
+
+        return out
+
+    @classmethod
+    def areas_as_geojson(cls, areas, srid=4326):
+        """ Return a geojson FeatureCollection dict for these areas.
+        """
+        out = {
+            'type': 'FeatureCollection',
             'crs': {
                 'type': 'name',
                 'properties': {'name': 'EPSG:%d' % srid},
             },
-            'properties': self.as_dict(),
-            'geometry': json.loads(polygons.geojson),
+            'features': [a.as_geojson() for a in areas],
         }
         return out
 

--- a/mapit/tests/test_views.py
+++ b/mapit/tests/test_views.py
@@ -93,7 +93,12 @@ class AreaViewsTest(TestCase):
     def test_multiple_area_geojson(self):
         url = '/areas/%d,%d.geojson' % (self.big_area.id, self.small_area_1.id)
         response = self.client.get(url)
-        content = json.loads("".join(response.streaming_content))
+
+        if hasattr(response, 'streaming_content'):
+            content = json.loads("".join(x.decode('utf-8') for x in response.streaming_content))
+        else:
+            content = json.loads(response.content)
+
         self.assertEqual(content['type'], 'FeatureCollection')
 
     def test_json_links(self):

--- a/mapit/tests/test_views.py
+++ b/mapit/tests/test_views.py
@@ -83,6 +83,19 @@ class AreaViewsTest(TestCase):
         response = self.client.get('/')
         self.assertContains(response, 'MapIt')
 
+    def test_geojson(self):
+        url = '/area/%d.geojson' % self.big_area.id
+        response = self.client.get(url)
+        content = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(content['type'], 'Feature')
+        self.assertEqual(content['properties']['name'], 'Big Area')
+
+    def test_multiple_area_geojson(self):
+        url = '/areas/%d,%d.geojson' % (self.big_area.id, self.small_area_1.id)
+        response = self.client.get(url)
+        content = json.loads("".join(response.streaming_content))
+        self.assertEqual(content['type'], 'FeatureCollection')
+
     def test_json_links(self):
         id = self.big_area.id
         url = '/area/%d/covers.html?type=SML' % id

--- a/mapit/urls.py
+++ b/mapit/urls.py
@@ -45,6 +45,7 @@ urlpatterns = [
     url(r'^nearest/(?P<srid>[0-9]+)/(?P<x>[0-9.-]+),(?P<y>[0-9.-]+)%s$' % format_end, postcodes.nearest),
 
     url(r'^areas/(?P<area_ids>[0-9]+(?:,[0-9]+)*)%s$' % format_end, areas.areas),
+    url(r'^areas/(?P<area_ids>[0-9]+(?:,[0-9]+)*)\.(?P<format>geojson)$', areas.areas_polygons),
     url(r'^areas/(?P<area_ids>[0-9]+(?:,[0-9]+)*)/geometry$', areas.areas_geometry),
     url(r'^areas/(?P<type>[A-Z0-9,]*[A-Z0-9]+)%s$' % format_end, areas.areas_by_type),
     url(r'^areas/(?P<name>.+?)%s$' % format_end, areas.areas_by_name),

--- a/mapit/views/areas.py
+++ b/mapit/views/areas.py
@@ -245,14 +245,8 @@ def areas(request, area_ids, format='json'):
 
 @ratelimit(minutes=3, requests=100)
 def areas_polygons(request, area_ids, format):
-    args = query_args(request, format)
-    areas = []
-
-    for area_id in area_ids.split(','):
-        area_args = query_args_for_area_id(request, area_id)
-        area_args.update(args)
-        areas.extend(get_list_or_404(Area, format, **area_args))
-
+    area_ids = area_ids.split(',')
+    areas = Area.objects.filter(id__in=area_ids)
     return output_areas(request, 'Area polygons by ID lookup', format, areas)
 
 


### PR DESCRIPTION
This includes the same details in an area's .geojson representation as in its .json representation. This is very useful when using .geojson on a webpage via CORS and saves you making two requests.

We have to build our own geojson manually, because the Django support for geojson doesn't gives us the opportunity to plug in custom properties.
