### PR TITLE
Add a command to raise the generation_high on current areas

### DIFF
--- a/mapit/management/commands/mapit_generation_raise_on_current_areas.py
+++ b/mapit/management/commands/mapit_generation_raise_on_current_areas.py
@@ -1,0 +1,77 @@
+# If you've created a new generation for importing a new data set into
+# a MapIt database with lots of existing active areas, you need to
+# raise generation_high on all of those areas to be the ID of the new
+# generation, or when you activate that new generation, none of the
+# existing areas will be shown in results. This command provides a
+# safe way of raising the generation_high of all active areas to the
+# ID of the new inactive generation.
+
+from optparse import make_option
+
+from django.core.management.base import BaseCommand, CommandError
+
+from mapit.models import Area, Generation, Type, Country
+
+
+def check_option(option_name, options, model_class):
+    '''Get a model instance from an option specifying its code field'''
+
+    supplied = options[option_name]
+    if not supplied:
+        return None
+    known = model_class.objects.order_by('code'). \
+        values_list('code', flat=True)
+    try:
+        return model_class.objects.get(code=supplied)
+    except model_class.DoesNotExist:
+        raise CommandError(
+            'The {option_name} {supplied} is not known - did you mean '
+            'one of: {known}'.format(
+                supplied=supplied,
+                known=', '.join(known),
+                option_name=option_name
+            )
+        )
+
+
+class Command(BaseCommand):
+    help = "Raise generation_high on active areas to the new generation's ID"
+    option_list = BaseCommand.option_list + (
+        make_option('--commit', action='store_true', dest='commit',
+                    help='Actually update the database'),
+        make_option('--country',
+                    help='Only raise the generation on areas with this country code'),
+        make_option('--type',
+                    help='Only raise the generation on areas with this area type code'),
+    )
+
+    def handle(self, **options):
+        area_type = check_option('type', options, Type)
+        country = check_option('country', options, Country)
+
+        new_generation = Generation.objects.new()
+        if not new_generation:
+            raise CommandError("There is no new inactive generation")
+        current_generation = Generation.objects.current()
+        if not current_generation:
+            raise CommandError("There is no currently active generation")
+
+        qs = Area.objects.filter(generation_high=current_generation)
+        if area_type:
+            qs = qs.filter(type=area_type)
+        if country:
+            qs = qs.filter(country=country)
+
+        if options['commit']:
+            updated = qs.update(generation_high=new_generation)
+            message = "Successfully updated generation_high on {0} areas"
+            self.stdout.write(message.format(updated))
+        else:
+            self.stdout.write("Not updating since --commit wasn't specified")
+            self.stdout.write(
+                "But this would have set generation_high to {0} on:".format(
+                    new_generation
+                )
+            )
+            for a in qs:
+                self.stdout.write("  " + str(a))

--- a/mapit/tests/test_generation_commands.py
+++ b/mapit/tests/test_generation_commands.py
@@ -1,0 +1,182 @@
+from django.test import TestCase
+from django.core.management import call_command, CommandError
+from django.utils.six import StringIO
+
+from ..models import Area, Country, Generation, Type
+
+
+class GenerationCommandTests(TestCase):
+    """Tests for commands that manipulate MapIt generations"""
+
+    def test_no_generations(self):
+        with self.assertRaisesRegexp(CommandError, r'no new inactive'):
+            call_command(
+                'mapit_generation_raise_on_current_areas',
+                commit=True,
+                stderr=StringIO(),
+                stdout=StringIO()
+            )
+
+    def test_no_active_generations(self):
+        Generation.objects.create(
+            active=False,
+            description="One inactive generation",
+        )
+        with self.assertRaisesRegexp(CommandError, r'no currently active'):
+            call_command(
+                'mapit_generation_raise_on_current_areas',
+                commit=True,
+                stderr=StringIO(),
+                stdout=StringIO()
+            )
+
+    def test_should_raise_generation_of_one_area(self):
+        area_type = Type.objects.create(
+            code='VIL',
+            description='Villages in Trumptonshire'
+        )
+
+        first = Generation.objects.create(
+            active=True,
+            description="First active generation",
+        )
+        current = Generation.objects.create(
+            active=True,
+            description="Current active generation",
+        )
+        inactive = Generation.objects.create(
+            active=False,
+            description="New inactive generation",
+        )
+        area_trumpton = Area.objects.create(
+            name='Trumpton',
+            generation_low=first,
+            generation_high=current,
+            type=area_type,
+        )
+        area_chigley = Area.objects.create(
+            name='Chigley',
+            generation_low=first,
+            generation_high=first,
+            type=area_type,
+        )
+
+        stdout = StringIO()
+        call_command(
+            'mapit_generation_raise_on_current_areas',
+            commit=True,
+            stderr=StringIO(),
+            stdout=stdout,
+        )
+
+        # The old areas will still be cached by the ORM, so refetch them:
+        area_trumpton = Area.objects.get(pk=area_trumpton.id)
+        area_chigley = Area.objects.get(pk=area_chigley.id)
+
+        self.assertEqual(
+            stdout.getvalue(),
+            'Successfully updated generation_high on 1 areas\n'
+        )
+
+        self.assertEqual(area_trumpton.generation_low, first)
+        self.assertEqual(area_trumpton.generation_high, inactive)
+        self.assertEqual(area_chigley.generation_low, first)
+        self.assertEqual(area_chigley.generation_high, first)
+
+    def test_country_restriction(self):
+        scotland = Country.objects.create(code='S', name='Scotland')
+        england = Country.objects.create(code='E', name='England')
+
+        area_type = Type.objects.create(
+            code='WMC', description='Westminster Constituency'
+        )
+
+        current = Generation.objects.create(
+            active=True,
+            description="Current active generation",
+        )
+        inactive = Generation.objects.create(
+            active=False,
+            description="New inactive generation",
+        )
+
+        ed = Area.objects.create(
+            name='Edinburgh East',
+            country=scotland,
+            generation_high=current,
+            generation_low=current,
+            type=area_type
+        )
+        ca = Area.objects.create(
+            name='South Cambridgeshire',
+            country=england,
+            generation_high=current,
+            generation_low=current,
+            type=area_type
+        )
+
+        stdout = StringIO()
+
+        call_command(
+            'mapit_generation_raise_on_current_areas',
+            commit=True,
+            country='S',
+            stderr=StringIO(),
+            stdout=stdout,
+        )
+
+        ed = Area.objects.get(pk=ed.id)
+        ca = Area.objects.get(pk=ca.id)
+
+        self.assertEqual(ed.generation_high, inactive)
+        self.assertEqual(ca.generation_high, current)
+
+    def test_area_type_restriction(self):
+        scotland = Country.objects.create(code='S', name='Scotland')
+
+        area_type_wmc = Type.objects.create(
+            code='WMC', description='Westminster Constituency'
+        )
+        area_type_uta = Type.objects.create(
+            code='UTA', description='Unitary Authority'
+        )
+
+        current = Generation.objects.create(
+            active=True,
+            description="Current active generation",
+        )
+        inactive = Generation.objects.create(
+            active=False,
+            description="New inactive generation",
+        )
+
+        area_wmc = Area.objects.create(
+            name='Edinburgh East',
+            country=scotland,
+            generation_high=current,
+            generation_low=current,
+            type=area_type_wmc
+        )
+        area_uta = Area.objects.create(
+            name='City of Edinburgh Council',
+            country=scotland,
+            generation_high=current,
+            generation_low=current,
+            type=area_type_uta
+        )
+
+        stdout = StringIO()
+
+        call_command(
+            'mapit_generation_raise_on_current_areas',
+            commit=True,
+            type='WMC',
+            stderr=StringIO(),
+            stdout=stdout,
+        )
+
+        area_wmc = Area.objects.get(pk=area_wmc.id)
+        area_uta = Area.objects.get(pk=area_uta.id)
+
+        self.assertEqual(area_wmc.generation_high, inactive)
+        self.assertEqual(area_uta.generation_high, current)


### PR DESCRIPTION
This is useful if you've created a new generation for a new data
import, but there are existing areas in the database that should
still remain active after you've activated your new generation.
After creating the new inactive generation you can run this command
to raise the generation_high of any areas who have a generation_high
set to the current (i.e. most recent active) generation so that
they're the newly created generation.

You could do this in the Django shell, but this seems like a safer
way of doing this.