### PR TITLE
Fix bug parsing KML with Unicode filename.

### DIFF
--- a/mapit_global/management/commands/mapit_global_import.py
+++ b/mapit_global/management/commands/mapit_global_import.py
@@ -163,7 +163,7 @@ class Command(LabelCommand):
 
                 # Need to parse the KML manually to get the ExtendedData
                 kml_data = KML()
-                xml.sax.parse(kml_filename, kml_data)
+                xml.sax.parse(smart_str(kml_filename), kml_data)
 
                 useful_names = [n for n in kml_data.data.keys() if not n.startswith('Boundaries for')]
                 if len(useful_names) == 0:


### PR DESCRIPTION
The xml.sax module in python2 prior to 2.7.4 cannot handle a Unicode
filename (this was Python issue https://bugs.python.org/issue11159).
Make sure that we pass a str to xml.sax, which should be fine in any
version of python. Fixes #206.