### PR TITLE
Fix GDAL error in mapit_import tests

### DIFF
--- a/mapit/tests/test_import_commands.py
+++ b/mapit/tests/test_import_commands.py
@@ -4,12 +4,20 @@ from django.test import TestCase
 from django.core.management import call_command
 from django.conf import settings
 from django.utils.six import StringIO
+from django.contrib.gis.gdal.prototypes import ds
 
 from ..models import Type, NameType, Area, Generation, Country
 
 
 class MapitImportTest(TestCase):
     """Test the mapit_import management command"""
+
+    def setUp(self):
+        # Forcefully register a GDAL datasource driver, because Django has a
+        # bug where it assumes that any existing drivers mean they're all
+        # available, which doesn't seem to be the case.
+        if not ds.get_driver_count():
+            ds.register_all()
 
     def test_loads_kml_files(self):
         # Assert no areas in db before


### PR DESCRIPTION
When running the mapit tests as a group, something is leaving GDAL drivers
open/registered (I'm not sure of the terminology), but only Raster ones.

Django's Driver class checks for the existence of drivers before registering
new ones, but it assumes that if any exist, they all do: https://github.com/django/django/blob/b35adb0909b25a7dafc9212ddedfbf9b29dc05b8/django/contrib/gis/gdal/driver.py#L81-L83

In these tests that was not the case, so calls to the Vector driver resulted
in a pointer error. This commit provides a temporary workaround which force-
registers a driver (if none already exist) before the test runs.