### PR TITLE
Use modern transactions in mapit_UK_import_nspd_ni

### DIFF
--- a/mapit_gb/management/commands/mapit_UK_import_nspd_ni.py
+++ b/mapit_gb/management/commands/mapit_UK_import_nspd_ni.py
@@ -15,7 +15,6 @@
 
 import csv
 import os.path
-from django.db import transaction
 from mapit.models import Area
 from mapit.management.commands.mapit_import_postal_codes import Command
 
@@ -25,7 +24,6 @@ class Command(Command):
     args = '<NSPD CSV file>'
     option_defaults = {'strip': True, 'srid': 29902, 'coord-field-lon': 10, 'coord-field-lat': 11}
 
-    @transaction.commit_manually
     def handle_label(self, file, **options):
         # First set up the areas needed (as we have to match to postcode manually)
         self.euro_area = Area.objects.get(country__code='N', type__code='EUR')
@@ -98,4 +96,3 @@ class Command(Command):
     def post_row(self, pc):
         pc.areas.clear()
         pc.areas.add(*self.areas)
-        transaction.commit()


### PR DESCRIPTION
Django 1.6 deprecated `transaction.commit_manually` and Django 1.8 dropped
it entirely so we have to use modern transactions.  There's no direct upgrade
path from the old api to the modern one so just wrapping the relevant bit in
`transaction.atomic` seems reasonable.