### PR TITLE
October 2015 Boundary-Line

### DIFF
--- a/mapit_gb/controls/2009-10.py
+++ b/mapit_gb/controls/2009-10.py
@@ -14,6 +14,6 @@ def code_version():
     return 'ons'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match"""
     return False

--- a/mapit_gb/controls/2010-05.py
+++ b/mapit_gb/controls/2010-05.py
@@ -13,7 +13,7 @@ def code_version():
     return 'ons'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match"""
     if type == 'WMC' and country in ('E', 'W'):
         return True

--- a/mapit_gb/controls/2010-10.py
+++ b/mapit_gb/controls/2010-10.py
@@ -11,7 +11,7 @@ def code_version():
     return 'gss'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match"""
 
     return False

--- a/mapit_gb/controls/2011-05.py
+++ b/mapit_gb/controls/2011-05.py
@@ -18,7 +18,7 @@ def code_version():
 # Harrogate: Parish of Markingfield renamed Markenfield
 # Wiltshire: Parishes of Allcannings and Bower Chalke renamed All Cannings and Bowerchalke
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match against ONS code,
        or an Area to be used as an override instead"""
 

--- a/mapit_gb/controls/2011-10.py
+++ b/mapit_gb/controls/2011-10.py
@@ -33,7 +33,7 @@ def code_version():
     return 'gss'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match"""
 
     return False

--- a/mapit_gb/controls/2012-05.py
+++ b/mapit_gb/controls/2012-05.py
@@ -9,7 +9,7 @@ def code_version():
     return 'gss'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match against ONS code,
        or an Area to be used as an override instead"""
 

--- a/mapit_gb/controls/2012-10.py
+++ b/mapit_gb/controls/2012-10.py
@@ -7,6 +7,6 @@ def code_version():
     return 'gss'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match"""
     return False

--- a/mapit_gb/controls/2013-05.py
+++ b/mapit_gb/controls/2013-05.py
@@ -36,7 +36,7 @@ def code_version():
     return 'gss'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match"""
 
     if type != 'CED':

--- a/mapit_gb/controls/2013-10.py
+++ b/mapit_gb/controls/2013-10.py
@@ -11,7 +11,7 @@ def code_version():
     return 'gss'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match against
     an ONS code, or an Area to be used as an override instead."""
 

--- a/mapit_gb/controls/2014-05.py
+++ b/mapit_gb/controls/2014-05.py
@@ -9,7 +9,7 @@ def code_version():
     return 'gss'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match against
     an ONS code, or an Area to be used as an override instead."""
 

--- a/mapit_gb/controls/2014-10.py
+++ b/mapit_gb/controls/2014-10.py
@@ -9,5 +9,5 @@ def code_version():
     return 'gss'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     return False

--- a/mapit_gb/controls/2015-05.py
+++ b/mapit_gb/controls/2015-05.py
@@ -9,7 +9,7 @@ def code_version():
     return 'gss'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match against
     an ONS code, or an Area to be used as an override instead."""
 

--- a/mapit_gb/controls/2015-10.py
+++ b/mapit_gb/controls/2015-10.py
@@ -1,0 +1,51 @@
+# A control file for importing October 2015 Boundary-Line.
+
+# This control file assumes previous Boundary-Lines have been imported,
+# because it uses that information. If this is a first import, use the
+# first-gss control file.
+
+from mapit.models import Area, Generation
+
+
+def code_version():
+    return 'gss'
+
+
+def check(name, type, country, geometry, ons_code, **args):
+    """Should return True if this area is NEW, False if we should match against
+    an ONS code, or an Area to be used as an override instead."""
+
+    if type in ('WAC', 'WAE'):
+        # The May 2016+ boundaries have been given in Boundary-Line since
+        # October 2013. This was fixed for the October 2015 edition, by putting
+        # the old boundaries back, so we need to rejig things somehow. Easiest
+        # to put them in as new boundaries (even though they'll be same as old
+        # ones), but we'll have to remove the ONS code from the old ones so
+        # there aren't multiple results
+        a = Area.objects.get(codes__type__code='gss', codes__code=ons_code)
+        a.codes.filter(type__code='gss').delete()
+        return True
+
+    if type == 'CPC' and name == 'Wareham Town CP':
+        # Appeared in October 2013 edition with wrong ID, then both 201i4
+        # editions with right ID, then disappeared in May 2015 edition...
+        a = Area.objects.get(codes__type__code='gss', codes__code='E04012327')
+        a.generation_high = Generation.objects.current()
+        return a
+
+    # This is the default
+    return False
+
+
+def patch_boundary_line(name, ons_code, type):
+    """Used to fix mistakes in Boundary-Line. This patch function should return
+    True if we want to ignore the provided ONS code (and match only on unit
+    ID), or a new ONS code to replace it."""
+
+    # Two incorrect IDs given in the source
+    if name == 'Badgers Mount CP' and type == 'CPC' and ons_code == 'E04012604':
+        return 'E04012605'
+    if name == 'Shoreham CP' and type == 'CPC' and ons_code == 'E04012605':
+        return 'E04012606'
+
+    return False

--- a/mapit_gb/controls/first-gss.py
+++ b/mapit_gb/controls/first-gss.py
@@ -11,6 +11,6 @@ def code_version():
     return 'gss'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match"""
     return False

--- a/mapit_gb/controls/first-ons.py
+++ b/mapit_gb/controls/first-ons.py
@@ -14,6 +14,6 @@ def code_version():
     return 'ons'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match"""
     return False

--- a/mapit_gb/controls/possible-future.py
+++ b/mapit_gb/controls/possible-future.py
@@ -19,7 +19,7 @@ def code_version():
     return 'gss'
 
 
-def check(name, type, country, geometry):
+def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match"""
 
     if type != 'CED':

--- a/mapit_gb/management/commands/mapit_UK_import_boundary_line.py
+++ b/mapit_gb/management/commands/mapit_UK_import_boundary_line.py
@@ -119,7 +119,7 @@ class Command(LabelCommand):
             # Do parents in separate P-in-P code after this is done.
 
             try:
-                check = control.check(name, area_code, country, feat.geom)
+                check = control.check(name, area_code, country, feat.geom, ons_code=ons_code)
                 if check is True:
                     raise Area.DoesNotExist
                 if isinstance(check, Area):

--- a/mapit_gb/management/commands/mapit_UK_import_boundary_line.py
+++ b/mapit_gb/management/commands/mapit_UK_import_boundary_line.py
@@ -59,7 +59,10 @@ class Command(LabelCommand):
             ons_code = feat['CODE'].value if feat['CODE'].value not in ('999999', '999999999') else None
             unit_id = str(feat['UNIT_ID'].value)
             area_code = feat['AREA_CODE'].value
-            patch = self.patch_boundary_line(ons_code, area_code)
+            if hasattr(control, 'patch_boundary_line'):
+                patch = control.patch_boundary_line(name, ons_code, area_code)
+            else:
+                patch = self.patch_boundary_line(ons_code, area_code)
             if patch is True:
                 ons_code = None
             elif patch:
@@ -180,7 +183,9 @@ class Command(LabelCommand):
             save_polygons(self.ons_code_to_shape)
 
     def patch_boundary_line(self, ons_code, area_code):
-        """Fix mistakes in Boundary-Line"""
+        """Used to fix mistakes in Boundary-Line. This patch function should
+        return True if we want to ignore the provided ONS code (and match only
+        on unit ID), or a new ONS code to replace it."""
         if area_code == 'WMC' and ons_code == '42UH012':
             return True
         if area_code == 'UTA' and ons_code == 'S16000010':


### PR DESCRIPTION
Couple of issues to work around this time:
- [x] Incorrect parish IDs
- [x] Parish has come back
- [x] Wales & Scotland have been wrong in Boundary-Line for ages: "It transpires that the National Assembly for Wales constituencies and regions have been updated prematurely within Boundary-Line releases Oct 2013-May 2015, regarding the Parliamentary Constituencies and Assembly Electoral Regions (Wales) (Amendment) Order 2011. These will be amended to their correct alignment in the October 2015 release. Please note that this Order and the amendments do not come into force until the next National Assembly for Wales’s election in May 2016; they will be made available in the May 2016 Boundary-Line release."