### PR TITLE
Changes after a fresh import

### DIFF
--- a/mapit_gb/controls/first-gss.py
+++ b/mapit_gb/controls/first-gss.py
@@ -14,3 +14,17 @@ def code_version():
 def check(name, type, country, geometry, **args):
     """Should return True if this area is NEW, False if we should match"""
     return False
+
+
+def patch_boundary_line(name, ons_code, type):
+    """Used to fix mistakes in Boundary-Line. This patch function should return
+    True if we want to ignore the provided ONS code (and match only on unit
+    ID), or a new ONS code to replace it."""
+
+    # Two incorrect IDs given in the source
+    if name == 'Badgers Mount CP' and type == 'CPC' and ons_code == 'E04012604':
+        return 'E04012605'
+    if name == 'Shoreham CP' and type == 'CPC' and ons_code == 'E04012605':
+        return 'E04012606'
+
+    return False

--- a/mapit_gb/management/commands/mapit_UK_add_ons_to_gss.py
+++ b/mapit_gb/management/commands/mapit_UK_add_ons_to_gss.py
@@ -21,9 +21,11 @@ def process(new_code, old_code):
         return
 
     try:
-        area.codes.create(type=CodeType.objects.get(code='ons'), code=old_code)
+        area.codes.create(
+            type=CodeType.objects.get(code='ons'), code=old_code)
     except IntegrityError:
-        raise Exception("Key already exists for %s, can't give it %s" % (area, old_code))
+        raise Exception(
+            "Key already exists for %s, can't give it %s" % (area, old_code))
 
 
 class Command(NoArgsCommand):

--- a/mapit_gb/management/commands/mapit_UK_add_ons_to_gss.py
+++ b/mapit_gb/management/commands/mapit_UK_add_ons_to_gss.py
@@ -1,6 +1,7 @@
 # This script is for a one off import of all the old ONS codes to a MapIt
 # containing only the new ones from a modern Boundary-Line.
 
+import codecs
 import csv
 import os.path
 from django.core.management.base import NoArgsCommand
@@ -29,13 +30,21 @@ class Command(NoArgsCommand):
     help = 'Inserts the old ONS codes into mapit'
 
     def handle_noargs(self, **options):
-        mapping = csv.reader(open(os.path.dirname(__file__) + '/../../data/BL-2010-10-code-change.csv'))
+        code_changes = codecs.open(os.path.join(
+            os.path.dirname(__file__),
+            '../../data/BL-2010-10-code-change.csv'
+            ), 'r', 'latin-1')
+        mapping = csv.reader(code_changes)
         next(mapping)
         for row in mapping:
             new_code, name, old_code = row[0], row[1], row[3]
             process(new_code, old_code)
 
-        mapping = csv.reader(open(os.path.dirname(__file__) + '/../../data/BL-2010-10-missing-codes.csv'))
+        missing_codes = codecs.open(os.path.join(
+            os.path.dirname(__file__),
+            '../../data/BL-2010-10-missing-codes.csv'
+            ), 'r', 'latin-1')
+        mapping = csv.reader(missing_codes)
         next(mapping)
         for row in mapping:
             type, new_code, old_code, name = row


### PR DESCRIPTION
Here are 3 commits I made whilst importing the data from scratch.

`Patch incorrect IDs in first-gss control file` is because `patch_boundary_line` is needed on the initial import, however the patch function was missing from the `first-import` file.

`Open CSV files with the correct encoding` might just be an issue with python 3, but I think it's backwards compatible.

And the last one is just a small pep8 update that I thought should be it's own commit.
