### PR TITLE
Police import

### DIFF
--- a/mapit_gb/fixtures/uk_police.json
+++ b/mapit_gb/fixtures/uk_police.json
@@ -1,0 +1,6 @@
+[
+    { "model": "mapit.type", "fields": { "code": "PDG", "description": "Police force" } },
+    { "model": "mapit.codetype", "fields": { "code": "police_id", "description": "data.gov.uk force boundary KMLs" } },
+    { "model": "mapit.nametype", "fields": { "code": "P", "description": "Police API" } }
+
+]

--- a/mapit_gb/management/commands/mapit_UK_import_police_force_areas.py
+++ b/mapit_gb/management/commands/mapit_UK_import_police_force_areas.py
@@ -116,7 +116,7 @@ class Command(LabelCommand):
                 names_data_filename)
             url = "http://data.police.uk/api/forces"
             forces = urllib.request.urlopen(url)
-            with open(names_data_filename, 'w') as f:
+            with open(names_data_filename, 'wb') as f:
                 f.write(forces.read())
             print("...successfully fetched and saved the force names data.")
 


### PR DESCRIPTION
As a helper to others, this fixtures file creates the types needed to run the police areas import command with the following:

`./manage.py mapit_UK_import_police_force_areas --commit --generation_id 1 --area_type_code PDG --name_type_code "P" --code_type "police_id" [path/to/police/kmls]`

I don't know where to document this, as the main docs don't seem to include anthing about the police importer.
