### PR TITLE
Use reverse so more redirects work when MapIt is mounted on a subpath

### DIFF
--- a/mapit/urls.py
+++ b/mapit/urls.py
@@ -22,7 +22,7 @@ urlpatterns = [
     url(r'^postcode/partial/(?P<postcode>[A-Za-z0-9 ]+)%s$' % format_end,
         postcodes.partial_postcode, name="mapit-postcode-partial"),
 
-    url(r'^area/(?P<area_id>[0-9A-Z]+)%s$' % format_end, areas.area),
+    url(r'^area/(?P<area_id>[0-9A-Z]+)%s$' % format_end, areas.area, name='area'),
     url(r'^area/(?P<area_id>[0-9]+)/example_postcode%s$' % format_end, postcodes.example_postcode_for_area),
     url(r'^area/(?P<area_id>[0-9]+)/children%s$' % format_end, areas.area_children),
     url(r'^area/(?P<area_id>[0-9]+)/geometry$', areas.area_geometry),
@@ -38,11 +38,11 @@ urlpatterns = [
 
     url(r'^point/$', areas.point_form_submitted),
     url(r'^point/(?P<srid>[0-9]+)/(?P<x>%s),(?P<y>%s)(?:/(?P<bb>box))?%s$' % (number, number, format_end),
-        areas.areas_by_point),
+        areas.areas_by_point, name='areas-by-point'),
     url(r'^point/latlon/(?P<lat>%s),(?P<lon>%s)(?:/(?P<bb>box))?%s$' % (number, number, format_end),
-        areas.areas_by_point_latlon),
+        areas.areas_by_point_latlon, name='areas-by-point-latlon'),
     url(r'^point/osgb/(?P<e>%s),(?P<n>%s)(?:/(?P<bb>box))?%s$' % (number, number, format_end),
-        areas.areas_by_point_osgb),
+        areas.areas_by_point_osgb, name='areas-by-point-osgb'),
 
     url(r'^nearest/(?P<srid>[0-9]+)/(?P<x>%s),(?P<y>%s)%s$' % (number, number, format_end), postcodes.nearest),
 

--- a/mapit/views/areas.py
+++ b/mapit/views/areas.py
@@ -341,7 +341,10 @@ def area_from_code(request, code_type, code_value, format='json'):
     except Area.MultipleObjectsReturned:
         message = _('There were multiple areas that matched code {0} = {1}.').format(code_type, code_value)
         raise ViewException(format, message, 500)
-    return HttpResponseRedirect("/area/%d%s" % (area.id, '.%s' % format if format else ''))
+    area_kwargs = {'area_id': area.id}
+    if format:
+        area_kwargs['format'] = format
+    return HttpResponseRedirect(reverse('area', kwargs=area_kwargs))
 
 
 @ratelimit(minutes=3, requests=100)
@@ -388,28 +391,36 @@ def areas_by_point(request, srid, x, y, bb=False, format='json'):
 
 @ratelimit(minutes=3, requests=100)
 def areas_by_point_latlon(request, lat, lon, bb=False, format=''):
-    return HttpResponseRedirect("/point/4326/%s,%s%s%s" % (
-        lon, lat, "/box" if bb else '', '.%s' % format if format else '')
-    )
+    point_kwargs = {'srid': '4326', 'x': lon, 'y': lat}
+    if bb:
+        point_kwargs['bb'] = bb
+    if format:
+        point_kwargs['format'] = format
+    redirect_path = reverse('areas-by-point', kwargs=point_kwargs)
+    return HttpResponseRedirect(redirect_path)
 
 
 @ratelimit(minutes=3, requests=100)
 def areas_by_point_osgb(request, e, n, bb=False, format=''):
-    return HttpResponseRedirect("/point/27700/%s,%s%s%s" % (
-        e, n, "/box" if bb else '', '.%s' % format if format else '')
-    )
+    point_kwargs = {'e': e, 'n': n}
+    if bb:
+        point_kwargs['bb'] = bb
+    if format:
+        point_kwargs['format'] = format
+    redirect_path = reverse('areas-by-point-osgb', kwargs=point_kwargs)
+    return HttpResponseRedirect(redirect_path)
 
 
 def point_form_submitted(request):
     latlon = request.POST.get('pc', None)
     if not request.method == 'POST' or not latlon:
-        return redirect('/')
+        return redirect('mapit_index')
     m = re.match('\s*([0-9.-]+)\s*,\s*([0-9.-]+)', latlon)
     if not m:
-        return redirect('/')
+        return redirect('mapit_index')
     lat, lon = m.groups()
     return redirect(
-        'mapit.views.areas.areas_by_point',
+        'areas-by-point',
         srid=4326, x=lon, y=lat, format='html'
     )
 

--- a/mapit_gb/countries.py
+++ b/mapit_gb/countries.py
@@ -1,5 +1,6 @@
 import re
 
+from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 
 from mapit.shortcuts import get_object_or_404
@@ -24,12 +25,15 @@ def area_code_lookup(request, area_id, format):
         args['type__code'] = 'OMF'
 
     area = get_object_or_404(Area, **args)
-    path = '/area/%d%s' % (area.id, '.%s' % format if format else '')
+    area_kwargs = {'area_id': area.id}
+    if format:
+        area_kwargs['format'] = format
+    redirect_path = reverse('area', kwargs=area_kwargs)
     # If there was a query string, make sure it's passed on in the
     # redirect:
     if request.META['QUERY_STRING']:
-        path += "?" + request.META['QUERY_STRING']
-    return HttpResponseRedirect(path)
+        redirect_path += "?" + request.META['QUERY_STRING']
+    return HttpResponseRedirect(redirect_path)
 
 
 def canonical_postcode(pc):


### PR DESCRIPTION
If you've included MapIt in another Django project, e.g. with:

    urlpatterns += patterns('',
        (r'^mapit/', include('mapit.urls')),
    )

... then some of the views that returned a redirect to a URL
constructed with string formatting would redirect to a path
that didn't include the 'mapit/' prefix.  If these paths are
constructed with reverse() instead, it works properly.

This also introduces some new URL pattern names, so the URL
patterns can be referred to more concisely.