### PR TITLE
Allow overriding of email subject prefix

### DIFF
--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -35,6 +35,9 @@ RATE_LIMIT:
 # Email address that errors should be sent to. Optional.
 BUGS_EMAIL: 'example@example.org'
 
+# Text to prepend to the subject of error emails. Overrides Django default. Optional.
+EMAIL_SUBJECT_PREFIX: '[MapIt] '
+
 #########################################################################
 
 # You can ignore all of the settings below this point in the file

--- a/project/settings.py
+++ b/project/settings.py
@@ -67,6 +67,9 @@ if config.get('BUGS_EMAIL'):
         ('mySociety bugs', config['BUGS_EMAIL']),
     )
 
+if config.get('EMAIL_SUBJECT_PREFIX'):
+    EMAIL_SUBJECT_PREFIX = config['EMAIL_SUBJECT_PREFIX']
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',


### PR DESCRIPTION
Offering this as it's a change we've made to our fork.

In GOV.UK we want to specify different email subject lines for MapIt emails in each environment.  This change allows the EMAIL_SUBJECT_PREFIX to be set in general.yml.

The space after the closing ']' in the example is intentional in order to format the full email subject nicely when it includes following text.