### PR TITLE
Add VagrantFile and setup instructions for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 .venv
 
 .DS_Store
+.vagrant

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+## Quick local setup
+
+You will need [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+and [Vagrant](https://www.vagrantup.com/docs/installation/).
+
+Clone this repo:
+
+    git clone git@github.com:mysociety/mapit.git
+    cd mapit
+
+Create, and SSH in to, the Vagrant VM:
+
+    vagrant up
+    vagrant ssh
+
+Inside the VM, run the Django dev server:
+
+    cd /vagrant/mapit
+    ./manage.py runserver 0.0.0.0:8000
+
+MapIt will be accessible at <http://localhost:8000> on the host machine.
+
+If you make changes to the stylesheets, you will need to recompile the Sass
+files, using the `bin/mapit_make_css` script (on your host if you want the map
+to update).
+
+## Full setup on your own server
+
+See <http://code.mapit.mysociety.org/>

--- a/VagrantFile
+++ b/VagrantFile
@@ -1,0 +1,54 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Enable NFS access to the disk
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/vagrant/mapit", :nfs => true
+
+  # NFS requires a host-only network
+  # This also allows you to test via other devices (e.g. mobiles) on the same
+  # network
+  config.vm.network :private_network, ip: "10.11.12.13"
+
+  # Django dev server
+  config.vm.network "forwarded_port", guest: 8000, host: 8000
+
+  # Give the VM a bit more power to speed things up
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.cpus = 2
+  end
+
+  # Provision the vagrant box
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+
+    chown vagrant:vagrant /vagrant
+    cd /vagrant/mapit
+
+    # Install the packages from conf/packages.ubuntu-trusty
+    xargs apt-get install -qq -y < conf/packages.ubuntu-trusty
+
+    # Create a postgresql user
+    su postgres -c 'psql -c "CREATE USER vagrant SUPERUSER CREATEDB"'
+
+    # Run install-as-user to set up a database, virtualenv, python, sass etc
+    su vagrant -c 'bin/install-as-user vagrant mapit.mysociety.org /vagrant'
+
+    # Nicer running of runserver
+    su vagrant -c '../virtualenv-mapit/bin/pip install pyinotify'
+
+    # Auto-activate virtualenv on login
+    echo >> /home/vagrant/.bashrc "source /vagrant/virtualenv-mapit/bin/activate"
+  SHELL
+
+end

--- a/conf/sysvinit.example
+++ b/conf/sysvinit.example
@@ -1,8 +1,8 @@
 #! /bin/sh
 ### BEGIN INIT INFO
 # Provides:          application-django-mapit
-# Required-Start:    $local_fs $network
-# Required-Stop:     $local_fs $network
+# Required-Start:    $local_fs $network postgresql
+# Required-Stop:     $local_fs $network postgresql
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Starts the gunicorn server for MapIt


### PR DESCRIPTION
I needed to get mapit.mysociety.org and global.mapit.mysociety.org running on my Mac today, to do https://github.com/mysociety/mapit.mysociety.org/issues/17.

Installing everything (postgres, postgis, gdal, etc) onto my Mac seemed like a right pain, so I borrowed the VagrantFile that @stevenday wrote for [the mapit.mysociety.org repo](https://github.com/mysociety/mapit.mysociety.org/commit/ebcd03a37f851fa4cb037476cfa12337f7c8a429#diff-23b6f443c01ea2efcb4f36eedfea9089) and tweaked it to work with my copy of mapit.

Have tested it on my Mac running OS X 10.10.4, Vagrant 1.7.4, and VirtualBox 5.0.10. Mostly works, although I get an error about `mailcatcher` not existing, at the end of the first `vagrant up`.