### PR TITLE
Update 'add_ons_to_gss' command to support CSVReader for Python 2

### DIFF
--- a/mapit_gb/management/commands/mapit_UK_add_ons_to_gss.py
+++ b/mapit_gb/management/commands/mapit_UK_add_ons_to_gss.py
@@ -4,6 +4,7 @@
 import codecs
 import csv
 import os.path
+import sys
 from django.core.management.base import NoArgsCommand
 from mapit.models import Area, CodeType
 from psycopg2 import IntegrityError
@@ -30,22 +31,30 @@ class Command(NoArgsCommand):
     help = 'Inserts the old ONS codes into mapit'
 
     def handle_noargs(self, **options):
-        code_changes = codecs.open(os.path.join(
+        python_version = sys.version_info[0]
+
+        code_change_file_path = os.path.join(
             os.path.dirname(__file__),
-            '../../data/BL-2010-10-code-change.csv'
-            ), 'r', 'latin-1')
-        mapping = csv.reader(code_changes)
+            '../../data/BL-2010-10-code-change.csv')
+        if python_version < 3:
+            mapping = csv.reader(open(code_change_file_path))
+        else:
+            code_changes = codecs.open(code_change_file_path, 'r', 'latin-1')
+            mapping = csv.reader(code_changes)
         next(mapping)
         for row in mapping:
-            new_code, name, old_code = row[0], row[1], row[3]
+            new_code, old_code = row[0], row[3]
             process(new_code, old_code)
 
-        missing_codes = codecs.open(os.path.join(
+        missing_codes_file_path = os.path.join(
             os.path.dirname(__file__),
-            '../../data/BL-2010-10-missing-codes.csv'
-            ), 'r', 'latin-1')
-        mapping = csv.reader(missing_codes)
+            '../../data/BL-2010-10-missing-codes.csv')
+        if python_version < 3:
+            mapping = csv.reader(open(missing_codes_file_path))
+        else:
+            missing_codes = codecs.open(missing_codes_file_path, 'r', 'latin-1')
+            mapping = csv.reader(missing_codes)
         next(mapping)
         for row in mapping:
-            type, new_code, old_code, name = row
+            new_code, old_code = row[1], row[2]
             process(new_code, old_code)


### PR DESCRIPTION
The command would error when running with Python 2.7, failing to recognise the Welsh characters `ô` and `â` with "UnicodeEncodeError: 'ascii' codec can't encode character u'\xf4' in position 16: ordinal not in range(128)". This is due to `csv.reader` changing between Python 2 and 3 - in 2 it expected a file-like object on which next() would return raw bytes, and in 3 one which would return unicode strings (found by @jennyd). We opt to explicitly check which version of Python is running and run the old code for < Python 3.

We also stop assigning `name` for the 'code-change.csv' as it is not used anywhere else in the script and the encoding probably won't be handled correctly with Python 2. We stop assigning `type` and `name` for 'missing-codes.csv' for the same reasons.