### PR TITLE
Split analytics code into partial for easy overrides

### DIFF
--- a/mapit/templates/mapit/analytics.html
+++ b/mapit/templates/mapit/analytics.html
@@ -1,0 +1,12 @@
+{% if GOOGLE_ANALYTICS %}
+<script type="text/javascript">
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', '{{ GOOGLE_ANALYTICS }}']);
+  _gaq.push(['_trackPageview']);
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+</script>
+{% endif %}

--- a/mapit/templates/mapit/base.html
+++ b/mapit/templates/mapit/base.html
@@ -27,18 +27,7 @@
     <meta name="robots" content="noindex, follow">
 {% endif %}
 
-{% if GOOGLE_ANALYTICS %}
-<script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', '{{ GOOGLE_ANALYTICS }}']);
-  _gaq.push(['_trackPageview']);
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-</script>
-{% endif %}
+    {% include "mapit/analytics.html" %}
 
 </head>
 <body>


### PR DESCRIPTION
Putting the analytics code into a partial makes it easier for individual cobrands (eg: MapIt UK) to override their analytics tracking setup – for example, to upgrade to Universal Analytics, or to define custom dimensions/metrics before the pageview event is sent.