### PR TITLE
Improve and sync number regex in URL/point form.

### DIFF
--- a/mapit/urls.py
+++ b/mapit/urls.py
@@ -2,13 +2,12 @@ from django.conf.urls import include, url
 from django.conf import settings
 from django.shortcuts import render
 
+from mapit.utils import re_number as number
 from mapit.views import areas, postcodes
 
 handler500 = 'mapit.shortcuts.json_500'
 
 format_end = '(?:\.(?P<format>html|json))?'
-
-number = '-?\d*\.?\d+'
 
 urlpatterns = [
     url(r'^$', render, {'template_name': 'mapit/index.html'}, 'mapit_index'),

--- a/mapit/utils.py
+++ b/mapit/utils.py
@@ -3,6 +3,9 @@ import re
 from mapit import countries
 
 
+re_number = '[+-]?(?:\d*\.)?\d+'
+
+
 def is_valid_postcode(pc):
     pc = re.sub('\s+', '', pc.upper())
 

--- a/mapit/views/areas.py
+++ b/mapit/views/areas.py
@@ -16,6 +16,7 @@ from mapit.models import Area, Generation, Geometry, Code, Name
 from mapit.shortcuts import output_json, output_html, output_polygon, get_object_or_404, set_timeout
 from mapit.middleware import ViewException
 from mapit.ratelimitcache import ratelimit
+from mapit.utils import re_number
 from mapit import countries
 from mapit.iterables import iterdict
 from mapit.geometryserialiser import GeometrySerialiser, TransformError
@@ -413,7 +414,7 @@ def point_form_submitted(request):
     latlon = request.POST.get('pc', None)
     if not request.method == 'POST' or not latlon:
         return redirect('mapit_index')
-    m = re.match('\s*([0-9.-]+)\s*,\s*([0-9.-]+)', latlon)
+    m = re.match('\s*(%s)\s*,\s*(%s)' % (re_number, re_number), latlon)
     if not m:
         return redirect('mapit_index')
     lat, lon = m.groups()


### PR DESCRIPTION
This should prevent errors where a submission such as '53.8487,2.9295.'
was matched and then could not be reversed.