### PR TITLE
Add missing files from packaged django-mapit

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,8 @@
 include LICENSE.txt README.rst
 recursive-include project *.py
-recursive-include mapit *.html *.json *.sql
+recursive-include mapit *.html *.json *.sql *.kml
 recursive-include mapit/static *
-recursive-include data *.csv *.sql
-recursive-include mapit_gb *.html *.json *.sql
+recursive-include mapit_gb *.html *.json *.csv *.tsv *.sql
 recursive-include mapit_no *.html *.json *.sql
 recursive-include mapit_it *.html *.json *.sql
 recursive-include mapit_za *.html *.json *.sql


### PR DESCRIPTION
Add all directories to the packaged version, exclude any Python cache files.

Fixes #289