### PR TITLE
Add OSM ref attribute as part of global import

### DIFF
--- a/mapit_global/fixtures/global.json
+++ b/mapit_global/fixtures/global.json
@@ -24,5 +24,6 @@
     { "pk": 20, "model": "mapit.type", "fields": { "code": "OWA", "description": "OSM Political Boundary (Ward)" } },
 
     { "pk": 1, "model": "mapit.codetype", "fields": { "code": "osm_rel", "description": "OSM relation" } },
-    { "pk": 2, "model": "mapit.codetype", "fields": { "code": "osm_way", "description": "OSM way" } }
+    { "pk": 2, "model": "mapit.codetype", "fields": { "code": "osm_way", "description": "OSM way" } },
+    { "pk": 3, "model": "mapit.codetype", "fields": { "code": "osm_attr_ref", "description": "OSM reference attribute" } }
 ]

--- a/mapit_global/management/commands/mapit_global_import.py
+++ b/mapit_global/management/commands/mapit_global_import.py
@@ -303,6 +303,17 @@ class Command(LabelCommand):
                     if old_lang_codes:
                         verbose('Removing deleted languages codes: ' + ' '.join(old_lang_codes))
                     m.names.filter(type__code__in=old_lang_codes).delete()
+
+                    osm_attr_ref = CodeType.objects.get(code='osm_attr_ref')
+                    try:
+                        m.codes.update_or_create(
+                            type=osm_attr_ref,
+                            defaults={'code': kml_data.data[name]['ref']},
+                        )
+                    except KeyError:
+                        # No `ref` found in KML data, remove any existing `ref` from area.
+                        m.codes.filter(type=osm_attr_ref).delete()
+
                     # If the boundary was the same, the old Code
                     # object will still be pointing to the same Area,
                     # which just had its generation_high incremented.


### PR DESCRIPTION
## What does this do?

This adds the `ref` attribute from OSM, if present, as a new kind of `Code` when performing a global import from KML files.

## Why was this needed?

This is part of the work adding Mapit as a source of area data in EveryPolitician - https://github.com/everypolitician/everypolitician/issues/595. This addition should make matching between Mapit/OSM and Wikidata simpler, which in turn will make it easier to reconcile the data between the two in EveryPolitician.

For a full explanation, see @mhl's comment - https://github.com/everypolitician/everypolitician/issues/595#issuecomment-288382893.