### PR TITLE
Add support for a 'country' filter in query parameters

### DIFF
--- a/mapit/templates/mapit/api/areas.html
+++ b/mapit/templates/mapit/api/areas.html
@@ -23,6 +23,7 @@
                 <li><i>generation</i>, {% trans "to return areas in that generation (type and name lookups only)" %}.</li>
                 <li><i>min_generation</i>, {% trans "to return areas since that generation (type and name lookups only)" %}.</li>
                 <li><i>type</i>, {% trans "to restrict results to a type or types (multiple separated by commas; name lookup only)" %}.</li>
+                <li><i>country</i>, {% trans "to restrict results to areas with particular country codes (multiple separated by commas; type and name lookups only)" %}.</li>
             </ul></dd>
 
             <dt>{% trans "Returns" %}:</dt>

--- a/mapit/templates/mapit/api/point.html
+++ b/mapit/templates/mapit/api/point.html
@@ -58,6 +58,11 @@
                                 <i>min_generation</i>, to return results since that generation.
                             {% endblocktrans %}
                         </li>
+                        <li>
+                            {% blocktrans trimmed %}
+                                <i>country</i>, to restrict results to areas with particular country codes (multiple country codes separated by commas).
+                            {% endblocktrans %}
+                        </li>
                     </ul>
                 </dd>
 

--- a/mapit/tests/test_query_args.py
+++ b/mapit/tests/test_query_args.py
@@ -1,0 +1,104 @@
+# coding=utf-8
+
+from django.test import TestCase
+
+from mapit.models import Generation
+from mapit.views.areas import query_args
+
+
+class FakeRequest(object):
+    def __init__(self, params):
+        self.GET = params
+
+
+class QueryArgsTest(TestCase):
+
+    def setUp(self):
+        self.old_generation = Generation.objects.create(
+            active=False,
+            description="Old test generation",
+        )
+        self.active_generation = Generation.objects.create(
+            active=True,
+            description="Test generation",
+        )
+
+    def test_no_type(self):
+        args = query_args(FakeRequest({}), 'json', None)
+        self.assertEqual(
+            args,
+            {
+                'generation_high__gte': self.active_generation.id,
+                'generation_low__lte': self.active_generation.id,
+            }
+        )
+
+    def test_one_type_in_query(self):
+        args = query_args(FakeRequest({'type': 'WMC'}), 'json', None)
+        self.assertEqual(
+            args,
+            {
+                'generation_high__gte': self.active_generation.id,
+                'generation_low__lte': self.active_generation.id,
+                'type__code': 'WMC',
+            }
+        )
+
+    def test_two_types_in_query(self):
+        args = query_args(FakeRequest({'type': 'WMC,EUR'}), 'json', None)
+        self.assertEqual(
+            args,
+            {
+                'generation_high__gte': self.active_generation.id,
+                'generation_low__lte': self.active_generation.id,
+                'type__code__in': ['WMC', 'EUR'],
+            }
+        )
+
+    def test_one_type_in_params(self):
+        args = query_args(FakeRequest({}), 'json', 'WMC')
+        self.assertEqual(
+            args,
+            {
+                'generation_high__gte': self.active_generation.id,
+                'generation_low__lte': self.active_generation.id,
+                'type__code': 'WMC',
+            }
+        )
+
+    def test_two_types_in_params(self):
+        args = query_args(FakeRequest({}), 'json', 'WMC,EUR')
+        self.assertEqual(
+            args,
+            {
+                'generation_high__gte': self.active_generation.id,
+                'generation_low__lte': self.active_generation.id,
+                'type__code__in': ['WMC', 'EUR'],
+            }
+        )
+
+    def test_generation_specified(self):
+        args = query_args(
+            FakeRequest({'generation': self.old_generation.id}),
+            'json',
+            None)
+        self.assertEqual(
+            args,
+            {
+                'generation_high__gte': self.old_generation.id,
+                'generation_low__lte': self.old_generation.id,
+            }
+        )
+
+    def test_min_generation_specified(self):
+        args = query_args(
+            FakeRequest({'min_generation': self.old_generation.id}),
+            'json',
+            None)
+        self.assertEqual(
+            args,
+            {
+                'generation_high__gte': self.old_generation.id,
+                'generation_low__lte': self.active_generation.id,
+            }
+        )

--- a/mapit/tests/test_query_args.py
+++ b/mapit/tests/test_query_args.py
@@ -102,3 +102,25 @@ class QueryArgsTest(TestCase):
                 'generation_low__lte': self.active_generation.id,
             }
         )
+
+    def test_one_country_in_query(self):
+        args = query_args(FakeRequest({'country': 'DE'}), 'json', None)
+        self.assertEqual(
+            args,
+            {
+                'generation_high__gte': self.active_generation.id,
+                'generation_low__lte': self.active_generation.id,
+                'country__code': 'DE',
+            }
+        )
+
+    def test_two_countries_in_query(self):
+        args = query_args(FakeRequest({'country': 'DE,FR'}), 'json', None)
+        self.assertEqual(
+            args,
+            {
+                'generation_high__gte': self.active_generation.id,
+                'generation_low__lte': self.active_generation.id,
+                'country__code__in': ['DE', 'FR'],
+            }
+        )

--- a/mapit/views/areas.py
+++ b/mapit/views/areas.py
@@ -364,8 +364,9 @@ def areas_by_point(request, srid, x, y, bb=False, format='json'):
 
     args = query_args(request, format)
     type = request.GET.get('type', '')
+    country = request.GET.get('country', '')
 
-    if type and method == 'polygon':
+    if (type or country) and method == 'polygon':
         args = dict(("area__%s" % k, v) for k, v in args.items())
         # So this is odd. It doesn't matter if you specify types, PostGIS will
         # do the contains test on all the geometries matching the bounding-box

--- a/mapit/views/areas.py
+++ b/mapit/views/areas.py
@@ -64,6 +64,7 @@ def query_args(request, format, type=None):
 
     if type is None:
         type = request.GET.get('type', '')
+    country_code = request.GET.get('country', '')
 
     args = {}
     if min_generation > -1:
@@ -71,10 +72,14 @@ def query_args(request, format, type=None):
             'generation_low__lte': generation,
             'generation_high__gte': min_generation,
         }
-    if ',' in type:
-        args['type__code__in'] = type.split(',')
-    elif type:
-        args['type__code'] = type
+    for attr, value in [
+            ('type', type),
+            ('country', country_code),
+    ]:
+        if ',' in value:
+            args[attr + '__code__in'] = value.split(',')
+        elif value:
+            args[attr + '__code'] = value
 
     return args
 


### PR DESCRIPTION
This change means that you can add `?country=E` (say) to queries for
multiple areas to restrict the results to those areas that have a
Country with code `E`.

This should be particularly helpful for global.mapit.mysociety.org
if we set an appropriate Country for each Area, since one is almost
always interested in results from a particular country.

Fixes #55
