### PR TITLE
Ensure PostGIS works in the new default Travis build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ language: python
 
 sudo: false
 
+addons:
+  postgresql: "9.6"
+  apt:
+    packages:
+      - postgresql-9.6-postgis-2.3
+
 matrix:
   include:
     - python: 3.2


### PR DESCRIPTION
The explict installation of PostgreSQL 9.6 and PostGIS 2.3 is due to
this problem with the new Travis container-based trusty build
environment:

  https://github.com/travis-ci/travis-ci/issues/6972