### PR TITLE
First stab at fixing /nearest

### DIFF
--- a/mapit/tests/test_views.py
+++ b/mapit/tests/test_views.py
@@ -117,6 +117,19 @@ class AreaViewsTest(TestCase):
             'code': 400, 'error': 'GetProj4StringSPI: Cannot find SRID (84) in spatial_ref_sys\n'
         })
 
+    def test_nearest(self):
+        url = '/nearest/4326/4,52.json'
+        response = self.client.get(url)
+        content = get_content(response)
+        self.assertEqual(content, {'postcode': {
+            'coordsyst': 'G',
+            'distance': 519051.0,
+            'easting': 295977,
+            'northing': 178963,
+            'postcode': 'PO14 1NT',
+            'wgs84_lat': 51.5, 'wgs84_lon': -3.5
+        }})
+
     def test_areas_polygon_valid(self):
         id1 = self.small_area_1.id
         id2 = self.small_area_2.id

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 exclude=migrations
-ignore=E123
+ignore=E123,E722
 max-line-length=119


### PR DESCRIPTION
Something about the recent move to Postgres 9.6 and PostGIS 2.3 caused
the /nearest query to take much longer than 10 seconds to complete.

This commit updates the query to use the ‘<->’ centroid distance operator
instead, which makes better use of the geoindex and is much faster to
execute.

Handily the work @dracos did to introduce the TrigramDistance function
into Django 1.10 was easily adapted for this purpose, as it uses the
same operator.

This needs a bit of tidying and refactoring before merging really.