### PR TITLE
 Add .map.html endpoint to show map of areas

### DIFF
--- a/mapit/shortcuts.py
+++ b/mapit/shortcuts.py
@@ -1,4 +1,5 @@
 import itertools
+import re
 
 from django import http
 from django.db import connection
@@ -23,14 +24,17 @@ class GEOS_JSONEncoder(DjangoJSONEncoder):
 
 
 def output_html(request, title, areas, **kwargs):
-    kwargs['json_url'] = request.get_full_path().replace('.html', '')
+    kwargs['json_url'] = re.sub('(\.map)?\.html', '', request.get_full_path())
     kwargs['title'] = title
     tpl = loader.render_to_string('mapit/data.html', kwargs, request=request)
     wraps = tpl.split('!!!DATA!!!')
 
     indent_areas = kwargs.get('indent_areas', False)
+    show_map = kwargs.get('show_map', False)
     item_tpl = loader.get_template('mapit/areas_item.html')
-    areas = map(lambda area: item_tpl.render({'area': area, 'indent_areas': indent_areas}), areas)
+    areas = map(lambda area: item_tpl.render({
+        'area': area, 'indent_areas': indent_areas, 'show_map': show_map,
+    }), areas)
     areas = defaultiter(areas, '<li>' + _('No matching areas found.') + '</li>')
     content = itertools.chain(wraps[0:1], areas, wraps[1:])
 

--- a/mapit/templates/mapit/area.html
+++ b/mapit/templates/mapit/area.html
@@ -36,31 +36,10 @@
     </header>
 
 {% if area.polygons.count %}
-<div id="map"><div id="leaflet"></div></div>
-<script>
-    var map = new L.Map("leaflet");
-    map.attributionControl.setPrefix('');
-    var osm = new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '{% trans 'Map © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors' %}',
-        maxZoom: 18
-    });
-    map.addLayer(osm);
-
-    reqwest({
-        url: "{% url "mapit_index" %}area/{{ area.id }}.geojson?simplify_tolerance=0.0001",
-        type: 'json',
-        success: function(data) {
-            var area = new L.GeoJSON(data);
-            area.on('dblclick', function(e){
-                var z = map.getZoom() + (e.originalEvent.shiftKey ? -1 : 1);
-                map.setZoomAround(e.containerPoint, z);
-            });
-            map.addLayer(area);
-            map.fitBounds(area.getBounds());
-        }
-    });
-
-</script>
+{% include "mapit/map/init.html" %}
+{% with area.id|slugify as area_id %}
+{% include "mapit/map/json.html" with geojson_url="area/"|add:area_id %}
+{% endwith %}
 {% endif %}
 
     <section class="details">

--- a/mapit/templates/mapit/areas_item.html
+++ b/mapit/templates/mapit/areas_item.html
@@ -10,3 +10,8 @@
     {% endwith %}
     {% endif %}
 </li>
+{% if show_map %}
+<script>
+mapit_areas.push({{ area.id }});
+</script>
+{% endif %}

--- a/mapit/templates/mapit/data.html
+++ b/mapit/templates/mapit/data.html
@@ -5,12 +5,36 @@
 
 {% block content %}
 
+{% if show_map %}
+    <header class="area_info">
+{% endif %}
+
 <h2>{{ title|safe }}</h2>
 
 <p>{% blocktrans %}Get <a href="{{ json_url }}">this data as JSON</a>{% endblocktrans %}</p>
 
+{% if show_map %}
+    </header>
+
+    {% include "mapit/map/init.html" %}
+    <script>
+        var mapit_areas = [];
+    </script>
+
+    <section class="details">
+{% endif %}
+
 <ol class="area_list">
     !!!DATA!!!
 </ol>
+
+{% if show_map %}
+    </section>
+
+    <script>
+        mapit_areas = mapit_areas.slice(0, 200);
+    </script>
+    {% include "mapit/map/json.html" with geojson_url="areas/' + mapit_areas + '"|safe %}
+{% endif %}
 
 {% endblock %}

--- a/mapit/templates/mapit/map/init.html
+++ b/mapit/templates/mapit/map/init.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+<div id="map"><div id="leaflet"></div></div>
+<script>
+    var map = new L.Map("leaflet");
+    map.attributionControl.setPrefix('');
+    var osm = new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '{% trans 'Map © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors' %}',
+        maxZoom: 18
+    });
+    map.addLayer(osm);
+</script>

--- a/mapit/templates/mapit/map/json.html
+++ b/mapit/templates/mapit/map/json.html
@@ -1,0 +1,16 @@
+{% url "mapit_index" as index_url %}
+<script>
+    reqwest({
+        url: '{{ index_url }}{{ geojson_url }}.geojson?simplify_tolerance=0.0001',
+        type: 'json',
+        success: function(data) {
+            var area = new L.GeoJSON(data);
+            area.on('dblclick', function(e){
+                var z = map.getZoom() + (e.originalEvent.shiftKey ? -1 : 1);
+                map.setZoomAround(e.containerPoint, z);
+            });
+            map.addLayer(area);
+            map.fitBounds(area.getBounds());
+        }
+    });
+</script>

--- a/mapit/templates/mapit/postcode.html
+++ b/mapit/templates/mapit/postcode.html
@@ -27,20 +27,12 @@
 </header>
 
 {% if postcode.wgs84_lat or postcode.wgs84_lon %}
-<div id="map"><div id="leaflet"></div></div>
+{% include "mapit/map/init.html" %}
 <script>
-    var map = new L.Map("leaflet");
-    map.attributionControl.setPrefix('');
-    var osm = new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '{% trans 'Map © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors' %}',
-        maxZoom: 18
-    });
-
     var point = new L.LatLng({{ postcode.wgs84_lat|floatformat:-6 }}, {{ postcode.wgs84_lon|floatformat:-6 }});
     var marker = new L.Marker(point);
     map.addLayer(marker);
     map.setView(point, 14);
-    map.addLayer(osm);
 </script>
 {% endif %}
 

--- a/mapit/urls.py
+++ b/mapit/urls.py
@@ -8,6 +8,7 @@ from mapit.views import areas, postcodes
 handler500 = 'mapit.shortcuts.json_500'
 
 format_end = '(?:\.(?P<format>html|json))?'
+map_format_end = '(?:\.(?P<format>map\.html|html|json))?'
 
 urlpatterns = [
     url(r'^$', render, {'template_name': 'mapit/index.html'}, 'mapit_index'),
@@ -23,34 +24,34 @@ urlpatterns = [
 
     url(r'^area/(?P<area_id>[0-9A-Z]+)%s$' % format_end, areas.area, name='area'),
     url(r'^area/(?P<area_id>[0-9]+)/example_postcode%s$' % format_end, postcodes.example_postcode_for_area),
-    url(r'^area/(?P<area_id>[0-9]+)/children%s$' % format_end, areas.area_children),
+    url(r'^area/(?P<area_id>[0-9]+)/children%s$' % map_format_end, areas.area_children),
     url(r'^area/(?P<area_id>[0-9]+)/geometry$', areas.area_geometry),
-    url(r'^area/(?P<area_id>[0-9]+)/touches%s$' % format_end, areas.area_touches),
-    url(r'^area/(?P<area_id>[0-9]+)/overlaps%s$' % format_end, areas.area_overlaps),
-    url(r'^area/(?P<area_id>[0-9]+)/covers%s$' % format_end, areas.area_covers),
-    url(r'^area/(?P<area_id>[0-9]+)/covered%s$' % format_end, areas.area_covered),
-    url(r'^area/(?P<area_id>[0-9]+)/coverlaps%s$' % format_end, areas.area_coverlaps),
-    url(r'^area/(?P<area_id>[0-9]+)/intersects%s$' % format_end, areas.area_intersects),
+    url(r'^area/(?P<area_id>[0-9]+)/touches%s$' % map_format_end, areas.area_touches),
+    url(r'^area/(?P<area_id>[0-9]+)/overlaps%s$' % map_format_end, areas.area_overlaps),
+    url(r'^area/(?P<area_id>[0-9]+)/covers%s$' % map_format_end, areas.area_covers),
+    url(r'^area/(?P<area_id>[0-9]+)/covered%s$' % map_format_end, areas.area_covered),
+    url(r'^area/(?P<area_id>[0-9]+)/coverlaps%s$' % map_format_end, areas.area_coverlaps),
+    url(r'^area/(?P<area_id>[0-9]+)/intersects%s$' % map_format_end, areas.area_intersects),
     url(r'^area/(?P<area_id>[0-9A-Z]+)\.(?P<format>kml|geojson|wkt)$', areas.area_polygon, name='area_polygon'),
     url(r'^area/(?P<srid>[0-9]+)/(?P<area_id>[0-9]+)\.(?P<format>kml|json|geojson|wkt)$',
         areas.area_polygon),
 
     url(r'^point/$', areas.point_form_submitted),
-    url(r'^point/(?P<srid>[0-9]+)/(?P<x>%s),(?P<y>%s)(?:/(?P<bb>box))?%s$' % (number, number, format_end),
+    url(r'^point/(?P<srid>[0-9]+)/(?P<x>%s),(?P<y>%s)(?:/(?P<bb>box))?%s$' % (number, number, map_format_end),
         areas.areas_by_point, name='areas-by-point'),
-    url(r'^point/latlon/(?P<lat>%s),(?P<lon>%s)(?:/(?P<bb>box))?%s$' % (number, number, format_end),
+    url(r'^point/latlon/(?P<lat>%s),(?P<lon>%s)(?:/(?P<bb>box))?%s$' % (number, number, map_format_end),
         areas.areas_by_point_latlon, name='areas-by-point-latlon'),
-    url(r'^point/osgb/(?P<e>%s),(?P<n>%s)(?:/(?P<bb>box))?%s$' % (number, number, format_end),
+    url(r'^point/osgb/(?P<e>%s),(?P<n>%s)(?:/(?P<bb>box))?%s$' % (number, number, map_format_end),
         areas.areas_by_point_osgb, name='areas-by-point-osgb'),
 
     url(r'^nearest/(?P<srid>[0-9]+)/(?P<x>%s),(?P<y>%s)%s$' % (number, number, format_end), postcodes.nearest),
 
-    url(r'^areas/(?P<area_ids>[0-9]+(?:,[0-9]+)*)%s$' % format_end, areas.areas),
+    url(r'^areas/(?P<area_ids>[0-9]+(?:,[0-9]+)*)%s$' % map_format_end, areas.areas),
     url(r'^areas/(?P<area_ids>[0-9]+(?:,[0-9]+)*)\.(?P<format>kml|geojson)$', areas.areas_polygon),
     url(r'^areas/(?P<srid>[0-9]+)/(?P<area_ids>[0-9]+(?:,[0-9]+)*)\.(?P<format>kml|geojson)$', areas.areas_polygon),
     url(r'^areas/(?P<area_ids>[0-9]+(?:,[0-9]+)*)/geometry$', areas.areas_geometry),
-    url(r'^areas/(?P<type>[A-Z0-9,]*[A-Z0-9]+)%s$' % format_end, areas.areas_by_type),
-    url(r'^areas/(?P<name>.+?)%s$' % format_end, areas.areas_by_name),
+    url(r'^areas/(?P<type>[A-Z0-9,]*[A-Z0-9]+)%s$' % map_format_end, areas.areas_by_type),
+    url(r'^areas/(?P<name>.+?)%s$' % map_format_end, areas.areas_by_name),
     url(r'^areas$', areas.deal_with_POST, {'call': 'areas'}),
     url(r'^code/(?P<code_type>[^/]+)/(?P<code_value>[^/]+?)%s$' % format_end, areas.area_from_code),
 ]

--- a/mapit/views/areas.py
+++ b/mapit/views/areas.py
@@ -42,6 +42,9 @@ def add_codes(areas):
 
 def output_areas(request, title, format, areas, **kwargs):
     areas = add_codes(areas)
+    if format == 'map.html':
+        format = 'html'
+        kwargs['show_map'] = True
     if format == 'html':
         return output_html(request, title, areas, **kwargs)
     return output_json(iterdict((area.id, area.as_dict()) for area in areas))


### PR DESCRIPTION
This works for any list page (children/point/areas by name/etc). It restricts itself to the first 200 areas of the list if there are more.
As list pages are output streamed, it has to collect the IDs as it goes and do the map at the end; I think this should be okay for any sensible page.
Fixes #307