### PR TITLE
Fix marker icon

### DIFF
--- a/mapit/templates/mapit/base.html
+++ b/mapit/templates/mapit/base.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 {% load i18n %}
 
 <!DOCTYPE HTML>

--- a/mapit/templates/mapit/index.html
+++ b/mapit/templates/mapit/index.html
@@ -1,6 +1,5 @@
 {% extends "mapit/base.html" %}
 {% load i18n %}
-{% load static from staticfiles %}
 
 {% block fulltitle %}
     {% trans "MapIt : map postcodes and geographical points to administrative areas" %}

--- a/mapit/templates/mapit/postcode.html
+++ b/mapit/templates/mapit/postcode.html
@@ -30,6 +30,7 @@
 {% include "mapit/map/init.html" %}
 <script>
     var point = new L.LatLng({{ postcode.wgs84_lat|floatformat:-6 }}, {{ postcode.wgs84_lon|floatformat:-6 }});
+    L.Icon.Default.prototype.options.imagePath = '/static/mapit/leaflet/images/';
     var marker = new L.Marker(point);
     map.addLayer(marker);
     map.setView(point, 14);


### PR DESCRIPTION
Leaflet creates a div, reads its background image path and tries to remove the `url("` and `marker-icon.png")` from it, but because deployment has rewritten marker-icon.png to marker-icon.123456.png it doesn't work and makes a broken image. So we set it manually - it would be good not to hardcode `/static/` I guess, but is anyone going to use anything different really?