### PR TITLE
Switch to OGR kml/geojson generation.

### DIFF
--- a/mapit/geometryserialiser.py
+++ b/mapit/geometryserialiser.py
@@ -103,12 +103,12 @@ class GeometrySerialiser(object):
         if kml_type == "full":
             output = self.kml_header % (line_colour, fill_colour)
             for area in processed_areas:
-                output += self.kml_placemark % (escape(area[1].name), area[0].kml)
+                output += self.kml_placemark % (escape(area[1].name), area[0].ogr.kml)
             output += self.kml_footer
             return (output, content_type)
         elif kml_type == "polygon":
             if len(processed_areas) == 1:
-                return (processed_areas[0][0].kml, content_type)
+                return (processed_areas[0][0].ogr.kml, content_type)
             else:
                 raise Exception("kml_type: '%s' not supported for multiple areas"
                                 % (kml_type,))
@@ -120,7 +120,7 @@ class GeometrySerialiser(object):
         content_type = 'application/json'
         processed_areas = self.__process_polygons()
         if len(processed_areas) == 1 and self.single:
-            return (processed_areas[0][0].json, content_type)
+            return (processed_areas[0][0].ogr.json, content_type)
         else:
             output = {
                 'type': 'FeatureCollection',
@@ -135,7 +135,7 @@ class GeometrySerialiser(object):
         return {
             'type': 'Feature',
             'properties': {'name': area.name},
-            'geometry': json.loads(polygons.json),
+            'geometry': json.loads(polygons.ogr.json),
         }
 
     # output self.areas as wkt

--- a/mapit/tests/test_views.py
+++ b/mapit/tests/test_views.py
@@ -147,6 +147,11 @@ class AreaViewsTest(TestCase):
         self.assertEqual(response_area.status_code, 200)
         content_area = json.loads(response_area.content.decode('utf-8'))
 
+        url_area = '/area/%d.kml' % id
+        response_area = self.client.get(url_area)
+        self.assertEqual(response_area.status_code, 200)
+        self.assertContains(response_area, '<kml')
+
         url_areas = '/areas/%d.geojson' % id
         response_areas = self.client.get(url_areas)
         self.assertEqual(response_areas.status_code, 200)


### PR DESCRIPTION
This is far quicker than the GEOSGeometry outputs.
For one particular complicated boundary, 12 seconds down to 1 second.