### PR TITLE
Make POST to /areas CSRF-exempt

### DIFF
--- a/mapit/views/areas.py
+++ b/mapit/views/areas.py
@@ -418,6 +418,7 @@ def point_form_submitted(request):
 # ---
 
 
+@csrf_exempt
 def deal_with_POST(request, call='areas'):
     url = request.POST.get('URL', '')
     if not url:


### PR DESCRIPTION
There’s no need for POST protection on this URL as it
doesn’t modify any data or reveal anything specific to
a logged-in user.