### PR TITLE
Manually prefetch any matching many-many countries

### DIFF
--- a/mapit/views/areas.py
+++ b/mapit/views/areas.py
@@ -25,19 +25,29 @@ from mapit.geometryserialiser import GeometrySerialiser, TransformError
 
 def add_codes(areas):
     """Given an iterable of areas, return an iterator of those areas with codes
-    attached. We don't use prefetch_related because this can use a lot of
-    memory."""
+    and m2m countries attached. We don't use prefetch_related because this can
+    use a lot of memory."""
     codes = Code.objects.select_related('type').filter(area__in=areas)
+    countries = Area.countries.through.objects.select_related('country').filter(area__in=areas)
+
     lookup = {}
+    lookup_countries = {}
     for code in codes.iterator():
         lookup.setdefault(code.area_id, {})[code.type.code] = code.code
+    for m2m in countries.iterator():
+        c = m2m.country
+        lookup_countries.setdefault(m2m.area_id, []).append({'code': c.code, 'name': c.name})
+
     if isinstance(areas, QuerySet):
         if hasattr(countries, 'sorted_areas'):
             areas = countries.sorted_areas(areas)
         areas = areas.iterator()
+
     for area in areas:
         if area.id in lookup:
             area.all_codes = lookup[area.id]
+        if area.id in lookup_countries:
+            area.all_m2m_countries = lookup_countries[area.id]
         yield area
 
 


### PR DESCRIPTION
iterator() and prefetch() can't be used together, so the prefetch of many-many
countries is not happening in area lists, causing a slowdown if many areas are
to be returned. Instead, as we already do with codes, we manually fetch all of
the relevant countries from the join table and store them on the model objects
as we iterate through them.