### PR TITLE
Add Django 2.2 testing, drop Django 2.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 notifications:
   email: false
 
+dist: xenial
+
 language: python
 python: 3.5
 
@@ -10,7 +12,7 @@ addons:
   postgresql: "9.6"
   apt:
     packages:
-      - postgresql-9.6-postgis-2.3
+      - postgresql-9.6-postgis-2.4
 
 matrix:
   include:
@@ -23,8 +25,8 @@ env:
   matrix:
     - TOXENV=flake8
     - TOXENV=py35-1.11
-    - TOXENV=py35-2.0
     - TOXENV=py35-2.1
+    - TOXENV=py35-2.2
 
 install:
   - pip install tox codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py{27,35}-1.11, py35-{2.0,2.1}
+envlist = flake8, py{27,35}-1.11, py35-{2.1,2.2}
 
 [testenv]
 commands =
@@ -9,8 +9,8 @@ deps =
     py{27,35}: coverage
     flake8: flake8
     1.11: Django>=1.11,<2.0
-    2.0: Django>=2.0,<2.1
     2.1: Django>=2.1,<2.2
+    2.2: Django>=2.2,<3.0
 passenv = CFLAGS PYTHONWARNINGS
 setenv =
     py35: DYLD_FALLBACK_LIBRARY_PATH=/opt/local/lib:/usr/lib


### PR DESCRIPTION
Move Travis to xenial, as trusty only has GDAL 1.10, which Django 2.2 drops support for.