### PR TITLE
Use unary_union instead of cascaded_union.

### DIFF
--- a/mapit/management/command_utils.py
+++ b/mapit/management/command_utils.py
@@ -332,7 +332,7 @@ def fix_invalid_geos_multipolygon(geos_multipolygon):
                         raise Exception("Unknown fixed geometry type: " + fixed.geom_type)
         for_union = MultiPolygon(valid_polygons)
     if len(for_union) > 0:
-        result = for_union.cascaded_union
+        result = for_union.unary_union
         # If they have been unioned into a single Polygon, still return
         # a MultiPolygon, for consistency of return types:
         if result.geom_type == 'Polygon':

--- a/mapit/tests/test_doctests.py
+++ b/mapit/tests/test_doctests.py
@@ -1,0 +1,7 @@
+import doctest
+import mapit.management.command_utils
+
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(mapit.management.command_utils))
+    return tests


### PR DESCRIPTION
cascaded_union was deprecated in Django 1.10 and has been removed in 2.0.

The current Django requirement is >= 1.11.2 which is still fine.