### PR TITLE
Added import command and area type for travel to work areas

### DIFF
--- a/mapit_gb/fixtures/uk.json
+++ b/mapit_gb/fixtures/uk.json
@@ -54,6 +54,14 @@
 
     { "pk": 41, "model": "mapit.type", "fields": { "code": "CPW", "description": "Civil parish/community ward" } },
 
+    { "pk": 42, "model": "mapit.type", "fields": { "code": "NIW", "description": "Northern Ireland Ward" } },
+    { "pk": 43, "model": "mapit.type", "fields": { "code": "16W", "description": "Forward-dated ward boundaries" } },
+
+    { "pk": 44, "model": "mapit.type", "fields": { "code": "CCG", "description": "Clinical Commissioning Group" } },
+    { "pk": 45, "model": "mapit.type", "fields": { "code": "WLHB", "description": "Welsh Local Health Board" } },
+    { "pk": 46, "model": "mapit.type", "fields": { "code": "SHB", "description": "Scottish Health Board" } },
+    { "pk": 47, "model": "mapit.type", "fields": { "code": "NIHT", "description": "NI Health Trust" } },
+
     { "pk": 1, "model": "mapit.codetype", "fields": { "code": "ons", "description": "SNAC" } },
     { "pk": 2, "model": "mapit.codetype", "fields": { "code": "gss", "description": "GSS (SNAC replacement)" } },
     { "pk": 3, "model": "mapit.codetype", "fields": { "code": "unit_id", "description": "Boundary-Line (OS Admin Area ID)" } },

--- a/mapit_gb/fixtures/uk.json
+++ b/mapit_gb/fixtures/uk.json
@@ -62,6 +62,8 @@
     { "pk": 46, "model": "mapit.type", "fields": { "code": "SHB", "description": "Scottish Health Board" } },
     { "pk": 47, "model": "mapit.type", "fields": { "code": "NIHT", "description": "NI Health Trust" } },
 
+    { "pk": 48, "model": "mapit.type", "fields": { "code": "TTW", "description": "Travel to Work Areas" } },
+
     { "pk": 1, "model": "mapit.codetype", "fields": { "code": "ons", "description": "SNAC" } },
     { "pk": 2, "model": "mapit.codetype", "fields": { "code": "gss", "description": "GSS (SNAC replacement)" } },
     { "pk": 3, "model": "mapit.codetype", "fields": { "code": "unit_id", "description": "Boundary-Line (OS Admin Area ID)" } },

--- a/mapit_gb/templates/mapit/api/areas-types.html
+++ b/mapit_gb/templates/mapit/api/areas-types.html
@@ -8,7 +8,7 @@ MTD (Metropolitan district), MTW (Metropolitan ward), NIE (NI Assembly
 constituency), OLF (Lower Layer Super Output Area, Full), OLG (Lower Layer
 Super Output Area, Generalised), OMF (Middle Layer Super Output Area, Full),
 OMG (Middle Layer Super Output Area, Generalised), SPC (Scottish Parliament
-constituency), SPE (Scottish Parliament region), UTA (Unitary authority), UTE
-(Unitary authority electoral division), UTW (Unitary authority ward), WAC
-(Welsh Assembly constituency), WAE (Welsh Assembly region), WMC (UK
-Parliamentary constituency)</small>.
+constituency), SPE (Scottish Parliament region), TTW (Travel to Work Area),
+UTA (Unitary authority), UTE (Unitary authority electoral division),
+UTW (Unitary authority ward), WAC (Welsh Assembly constituency),
+WAE (Welsh Assembly region), WMC (UK Parliamentary constituency)</small>.


### PR DESCRIPTION
Creates new import command to import Travel to Work Areas (TTWA) into MapIt.

Sources file urls and example command:

`http://geoportal.statistics.gov.uk/datasets/d3062ec5f03b49a7be631d71586cac8c_0
`
```
python manage.py mapit_UK_import_ttwa Travel_to_Work_Areas_December_2011_Full_Clipped_Boundaries_in_United_Kingdom.shp
 --commit

```