### PR TITLE
Depend on psycopg2-binary instead of psycopg2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=[
         'Django >= 1.11.2',
         'libsass',
-        'psycopg2',
+        'psycopg2-binary',
         'PyYAML',
         'Shapely',
         'uk-postcode-utils',


### PR DESCRIPTION
This makes it possible to install the Python venv without the need to compile anything.

fixes #323 