### PR TITLE
October 2020 Boundary-Line import

### DIFF
--- a/mapit/management/find_parents.py
+++ b/mapit/management/find_parents.py
@@ -37,10 +37,11 @@ class FindParentsCommand(BaseCommand):
                         'generation_low__lte': new_generation,
                         'generation_high__gte': new_generation,
                     }
-                    if isinstance(self.parentmap[area.type.code], str):
-                        args['type__code'] = self.parentmap[area.type.code]
+                    parent_type = self.parentmap[area.type.code]
+                    if isinstance(parent_type, str):
+                        args['type__code'] = parent_type
                     else:
-                        args['type__code__in'] = self.parentmap[area.type.code]
+                        args['type__code__in'] = parent_type
                     parent = Area.objects.get(**args)
                     break
                 except Area.DoesNotExist:

--- a/mapit_gb/controls/2020-10.py
+++ b/mapit_gb/controls/2020-10.py
@@ -1,0 +1,42 @@
+# A control file for importing October 2020 Boundary-Line.
+
+import re
+from mapit.models import Area
+
+
+def code_version():
+    return 'gss'
+
+
+def check(name, type, country, geometry, ons_code, commit, **args):
+    """Should return True if this area is NEW, False if we should match against
+    an ONS code, or an Area to be used as an override instead."""
+
+    # The GLA area now has a GSS code, we should
+    # match it up with the existing area.
+    if type == 'GLA':
+        try:
+            area = Area.objects.get(type__code='GLA')
+            return area
+        except Area.DoesNotExist:
+            pass
+
+    # Boundary-Line has decided to continue the Buckinghamshire county/district
+    # ward boundaries but remove the councils. If we have run the script that
+    # created the Buckinghamshire UTA and UTWs, make sure we allow these in as
+    # new boundaries (though they'll be the same as old ones). We have to
+    # remove the ONS code from the old ones so there aren't multiple results.
+    if type in ('DIW', 'CED'):
+        try:
+            area_within = Area.objects.get(
+                type__code='UTA', polygons__polygon__contains=geometry.geos.point_on_surface)
+            if re.search('Buckinghamshire(?i)', area_within.name):
+                if ons_code:
+                    a = Area.objects.get(codes__type__code='gss', codes__code=ons_code)
+                    if commit:
+                        a.codes.filter(type__code='gss').delete()
+                return True
+        except Area.DoesNotExist:
+            pass
+
+    return False

--- a/mapit_gb/management/commands/mapit_UK_find_parents.py
+++ b/mapit_gb/management/commands/mapit_UK_find_parents.py
@@ -9,9 +9,11 @@ from mapit.management.find_parents import FindParentsCommand
 class Command(FindParentsCommand):
     parentmap = {
         # A District council ward's parent is a District council:
-        'DIW': 'DIS',
+        # Or a unitary in Buckinghamshire's case (2020)
+        'DIW': ('DIS', 'UTA'),
         # A County council ward's parent is a County council:
-        'CED': 'CTY',
+        # Or a unitary in Buckinghamshire's case (2020)
+        'CED': ('CTY', 'UTA'),
         # A London borough ward's parent is a London borough:
         'LBW': 'LBO',
         # A London Assembly constituency's parent is the Greater London Authority:


### PR DESCRIPTION
See #365.
Adds a control file that matches up the GLA area and allows CED/DIW through as new areas if inside a Buckinghamshire UTA.
And allows `find_parents` to accept a UTA parent for a CED/DIW also because of Buckinghamshire.