### PR TITLE
Django 3 support

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -28,8 +28,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.5]
-        thing-to-test: [flake8, 1.11, 2.2]
+        python-version: [3.6]
+        thing-to-test: [flake8, 1.11, 2.2, '3.0', 3.1]
         include:
           - python-version: 2.7
             thing-to-test: 1.11

--- a/mapit/iterables.py
+++ b/mapit/iterables.py
@@ -10,7 +10,7 @@ def defaultiter(it, default):
 
 
 # If you wanted iterdict() to be more generic, it'd be something like:
-# from django.utils import six
+# import six
 # import itertools
 # if not args:
 #     self.ITERABLE = iter()

--- a/mapit/management/commands/mapit_import.py
+++ b/mapit/management/commands/mapit_import.py
@@ -12,8 +12,8 @@ from django.core.management.base import LabelCommand, CommandError
 from django.contrib.gis.gdal import DataSource
 from django.contrib.gis.db.models import Collect
 from django.conf import settings
-from django.utils import six
-from django.utils.six.moves import input
+import six
+from six.moves import input
 
 from mapit.models import Area, Generation, Type, NameType, Country, CodeType
 from mapit.management.command_utils import save_polygons, fix_invalid_geos_geometry

--- a/mapit/management/commands/mapit_import_area_unions.py
+++ b/mapit/management/commands/mapit_import_area_unions.py
@@ -10,7 +10,7 @@ import csv
 from django.core.management.base import LabelCommand
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.db.models import Union
-from django.utils.six import Iterator
+from six import Iterator
 
 from mapit.models import Area, Generation, Geometry, Country, Type
 from mapit.management.command_utils import save_polygons

--- a/mapit/middleware/__init__.py
+++ b/mapit/middleware/__init__.py
@@ -1,7 +1,7 @@
 import itertools
 import re
 
-from django.utils import six
+import six
 
 from .view_error import ViewException, ViewExceptionMiddleware  # noqa
 

--- a/mapit/models.py
+++ b/mapit/models.py
@@ -3,11 +3,12 @@ from __future__ import unicode_literals
 import re
 import itertools
 
+from six import python_2_unicode_compatible
 from django.contrib.gis.db import models
 from django.conf import settings
 from django.db import connection
 from django.db.models.query import RawQuerySet
-from django.utils.encoding import python_2_unicode_compatible, smart_text
+from django.utils.encoding import smart_text
 from django.utils.functional import cached_property
 
 from mapit import countries

--- a/mapit/shortcuts.py
+++ b/mapit/shortcuts.py
@@ -1,12 +1,12 @@
 import itertools
 import re
 
+from six.moves import map
 from django import http
 from django.db import connection
 from django.conf import settings
 from django.shortcuts import get_object_or_404 as orig_get_object_or_404
 from django.template import loader
-from django.utils.six.moves import map
 from django.utils.translation import ugettext as _
 
 from mapit.iterables import defaultiter

--- a/mapit/tests/test_admin.py
+++ b/mapit/tests/test_admin.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.urls import reverse
-from django.utils.six import assertRegex
+from six import assertRegex
 
 
 class AdminViewsTest(TestCase):

--- a/mapit/tests/test_generation_commands.py
+++ b/mapit/tests/test_generation_commands.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.core.management import call_command, CommandError
-from django.utils.six import StringIO, assertRaisesRegex
+from six import StringIO, assertRaisesRegex
 
 from ..models import Area, Country, Generation, Type
 

--- a/mapit/tests/test_import_commands.py
+++ b/mapit/tests/test_import_commands.py
@@ -1,9 +1,9 @@
 import os
 
+from six import StringIO
 from django.test import TestCase
 from django.core.management import call_command
 from django.conf import settings
-from django.utils.six import StringIO
 from django.contrib.gis.gdal.prototypes import ds
 
 from ..models import Type, NameType, Area, Generation, Country

--- a/mapit/tests/test_query_args.py
+++ b/mapit/tests/test_query_args.py
@@ -1,7 +1,15 @@
 # coding=utf-8
 
+import django
 from django.db.models import Q
 from django.test import TestCase
+
+if django.get_version() < '2.0':
+    # Monkeypatch Q() so it sorts the arguments provided,
+    # so our tests can compare for equality
+    def q__init__(self, *args, **kwargs):
+        super(Q, self).__init__(children=list(args) + list(sorted(kwargs.items())))
+    Q.__init__ = q__init__
 
 from mapit.models import Generation
 from mapit.views.areas import query_args

--- a/mapit/views/areas.py
+++ b/mapit/views/areas.py
@@ -122,7 +122,7 @@ def check_area_ids(format, area_ids):
             raise ViewException(format, _('Bad area ID specified'), 400)
 
 
-def generations(request, format='json'):
+def generations(request, format=''):
     generations = Generation.objects.all()
     if format == 'html':
         return render(request, 'mapit/generations.html', {'generations': generations})
@@ -130,7 +130,7 @@ def generations(request, format='json'):
 
 
 @ratelimit
-def area(request, area_id, format='json'):
+def area(request, area_id, format=''):
     if hasattr(countries, 'area_code_lookup'):
         resp = countries.area_code_lookup(request, area_id, format)
         if resp:
@@ -196,7 +196,7 @@ def area_polygon(request, srid='', area_id='', format='kml'):
 
 
 @ratelimit
-def area_children(request, area_id, format='json'):
+def area_children(request, area_id, format=''):
     q = query_args(request, format)
     area = get_object_or_404(Area, format=format, id=area_id)
     children = area.children.filter(q).distinct()
@@ -232,44 +232,44 @@ def area_intersect(query_type, title, request, area_id, format):
 
 
 @ratelimit
-def area_touches(request, area_id, format='json'):
+def area_touches(request, area_id, format=''):
     return area_intersect('touches', _('Areas touching %s'), request, area_id, format)
 
 
 @ratelimit
-def area_overlaps(request, area_id, format='json'):
+def area_overlaps(request, area_id, format=''):
     return area_intersect('overlaps', _('Areas overlapping %s'), request, area_id, format)
 
 
 @ratelimit
-def area_covers(request, area_id, format='json'):
+def area_covers(request, area_id, format=''):
     return area_intersect('coveredby', _('Areas covered by %s'), request, area_id, format)
 
 
 @ratelimit
-def area_coverlaps(request, area_id, format='json'):
+def area_coverlaps(request, area_id, format=''):
     return area_intersect(['overlaps', 'coveredby'], _('Areas covered by or overlapping %s'), request, area_id, format)
 
 
 @ratelimit
-def area_covered(request, area_id, format='json'):
+def area_covered(request, area_id, format=''):
     return area_intersect('covers', _('Areas that cover %s'), request, area_id, format)
 
 
 @ratelimit
-def area_intersects(request, area_id, format='json'):
+def area_intersects(request, area_id, format=''):
     return area_intersect('intersects', _('Areas that intersect %s'), request, area_id, format)
 
 
 @ratelimit
-def areas(request, area_ids, format='json'):
+def areas(request, area_ids, format=''):
     area_ids = area_ids.split(',')
     areas = Area.objects.filter(id__in=area_ids)
     return output_areas(request, _('Areas ID lookup'), format, areas)
 
 
 @ratelimit
-def areas_by_type(request, type, format='json'):
+def areas_by_type(request, type, format=''):
     q = query_args(request, format, type)
     areas = Area.objects.filter(q).distinct()
     if format in ('kml', 'geojson'):
@@ -278,7 +278,7 @@ def areas_by_type(request, type, format='json'):
 
 
 @ratelimit
-def areas_by_name(request, name, format='json'):
+def areas_by_name(request, name, format=''):
     q = query_args(request, format)
     q &= Q(name__istartswith=name)
     areas = Area.objects.filter(q).distinct()
@@ -362,7 +362,7 @@ def areas_geometry(request, area_ids):
 
 
 @ratelimit
-def area_from_code(request, code_type, code_value, format='json'):
+def area_from_code(request, code_type, code_value, format=''):
     q = query_args(request, format)
     q &= Q(codes__type__code=code_type, codes__code=code_value)
     try:
@@ -380,7 +380,7 @@ def area_from_code(request, code_type, code_value, format='json'):
 
 
 @ratelimit
-def areas_by_point(request, srid, x, y, bb=False, format='json'):
+def areas_by_point(request, srid, x, y, bb=False, format=''):
     location = Point(float(x), float(y), srid=int(srid))
 
     use_exceptions()

--- a/mapit/views/postcodes.py
+++ b/mapit/views/postcodes.py
@@ -114,7 +114,7 @@ def postcode(request, postcode, format=None):
 
 
 @ratelimit
-def partial_postcode(request, postcode, format='json'):
+def partial_postcode(request, postcode, format=''):
     postcode = re.sub(r'\s+', '', postcode.upper())
     if is_valid_postcode(postcode):
         postcode = re.sub(r'\d[A-Z]{2}$', '', postcode)
@@ -139,7 +139,7 @@ def partial_postcode(request, postcode, format='json'):
 
 
 @ratelimit
-def example_postcode_for_area(request, area_id, format='json'):
+def example_postcode_for_area(request, area_id, format=''):
     area = get_object_or_404(Area, format=format, id=area_id)
     try:
         pc = Postcode.objects.filter(areas=area).order_by()[0]
@@ -171,7 +171,7 @@ def form_submitted(request):
 
 
 @ratelimit
-def nearest(request, srid, x, y, format='json'):
+def nearest(request, srid, x, y, format=''):
     location = Point(float(x), float(y), srid=int(srid))
     set_timeout(format)
 

--- a/mapit_gb/management/commands/mapit_UK_add_gss_codes_to_ni_areas.py
+++ b/mapit_gb/management/commands/mapit_UK_add_gss_codes_to_ni_areas.py
@@ -7,7 +7,7 @@ import os.path
 
 from django.core.management.base import BaseCommand
 from mapit.models import Area, Generation, Country, CodeType
-from django.utils import six
+import six
 
 
 class Command(BaseCommand):

--- a/mapit_gb/management/commands/mapit_UK_add_names_to_ni_areas.py
+++ b/mapit_gb/management/commands/mapit_UK_add_names_to_ni_areas.py
@@ -7,7 +7,7 @@ import os.path
 
 from django.core.management.base import BaseCommand
 from mapit.models import Area, Generation, Country, NameType
-from django.utils import six
+import six
 
 
 class Command(BaseCommand):

--- a/mapit_gb/management/commands/mapit_UK_fix_2011-10.py
+++ b/mapit_gb/management/commands/mapit_UK_fix_2011-10.py
@@ -4,7 +4,7 @@
 
 from django.core.management.base import LabelCommand
 from django.contrib.gis.gdal import DataSource
-from django.utils import six
+import six
 
 from mapit.models import Area, CodeType
 from utils import save_polygons

--- a/mapit_gb/management/commands/mapit_UK_fix_2012-05.py
+++ b/mapit_gb/management/commands/mapit_UK_fix_2012-05.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import re
 from django.core.management.base import LabelCommand
 from django.contrib.gis.gdal import DataSource
-from django.utils import six
+import six
 
 from mapit.models import Area, CodeType, Type, Country, Generation, NameType
 from utils import save_polygons

--- a/mapit_gb/management/commands/mapit_UK_fix_2013-10.py
+++ b/mapit_gb/management/commands/mapit_UK_fix_2013-10.py
@@ -8,7 +8,7 @@ import re
 
 from django.core.management.base import LabelCommand
 from django.contrib.gis.gdal import DataSource
-from django.utils import six
+import six
 
 from mapit.models import Area, Code, CodeType, Type, Country, Generation, NameType
 from mapit.management.command_utils import save_polygons

--- a/mapit_gb/management/commands/mapit_UK_fix_2019-05.py
+++ b/mapit_gb/management/commands/mapit_UK_fix_2019-05.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import re
 from django.core.management.base import LabelCommand
 from django.contrib.gis.gdal import DataSource
-from django.utils import six
+import six
 
 from mapit.models import Area, Code, CodeType, Type, Country, Generation, NameType
 from mapit.management.command_utils import save_polygons

--- a/mapit_gb/management/commands/mapit_UK_import_2011_scotparl.py
+++ b/mapit_gb/management/commands/mapit_UK_import_2011_scotparl.py
@@ -4,7 +4,7 @@ import re
 
 from django.core.management.base import LabelCommand
 from django.contrib.gis.gdal import DataSource
-from django.utils import six
+import six
 
 from mapit.models import Area, Generation, Country, Type, CodeType, NameType
 from mapit.management.command_utils import save_polygons

--- a/mapit_gb/management/commands/mapit_UK_import_boundary_line.py
+++ b/mapit_gb/management/commands/mapit_UK_import_boundary_line.py
@@ -10,7 +10,7 @@ from django.core.management.base import LabelCommand
 # Not using LayerMapping as want more control, but what it does is what this does
 # from django.contrib.gis.utils import LayerMapping
 from django.contrib.gis.gdal import DataSource
-from django.utils import six
+import six
 
 from mapit.models import Area, Name, Generation, Country, Type, CodeType, NameType, Code
 from mapit.management.command_utils import save_polygons, fix_invalid_geos_geometry

--- a/mapit_gb/management/commands/mapit_UK_import_osni.py
+++ b/mapit_gb/management/commands/mapit_UK_import_osni.py
@@ -7,11 +7,11 @@ import sys
 import csv
 import os
 
+import six
 from django.core.management.base import BaseCommand
 # Not using LayerMapping as want more control, but what it does is what this does
 # from django.contrib.gis.utils import LayerMapping
 from django.contrib.gis.gdal import DataSource
-from django.utils import six
 from django.conf import settings
 
 from mapit.models import Area, Name, Generation, Country, Type, CodeType, NameType

--- a/mapit_gb/management/commands/mapit_UK_import_police_force_areas.py
+++ b/mapit_gb/management/commands/mapit_UK_import_police_force_areas.py
@@ -17,7 +17,7 @@ import sys
 
 from django.core.management import call_command
 from django.core.management.base import LabelCommand
-from django.utils.six.moves import urllib
+from six.moves import urllib
 
 from mapit.models import Type, NameType, Country, CodeType
 

--- a/mapit_gb/tests.py
+++ b/mapit_gb/tests.py
@@ -2,7 +2,7 @@ import unittest
 from django.conf import settings
 from django.test import TestCase
 from django.contrib.gis.geos import Polygon, Point
-from django.utils.six.moves import urllib
+from six.moves import urllib
 
 from mapit import utils, models
 

--- a/mapit_no/management/commands/mapit_NO_import_osm.py
+++ b/mapit_no/management/commands/mapit_NO_import_osm.py
@@ -8,11 +8,11 @@
 import re
 import xml.sax
 
+import six
 from django.core.management.base import LabelCommand
 # Not using LayerMapping as want more control, but what it does is what this does
 # from django.contrib.gis.utils import LayerMapping
 from django.contrib.gis.gdal import DataSource
-from django.utils import six
 from django.utils.encoding import smart_str
 
 from mapit.models import Area, Generation, Country, Type, CodeType, NameType

--- a/project/wsgi_monitor.py
+++ b/project/wsgi_monitor.py
@@ -7,7 +7,7 @@ import sys
 import signal
 import threading
 import atexit
-from django.utils.six.moves import queue
+from six.moves import queue
 
 _interval = 1.0
 _times = {}

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'psycopg2',
         'PyYAML',
         'Shapely',
+        'six',
         'uk-postcode-utils',
     ],
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,19 @@
 [tox]
-envlist = flake8, py{27,35}-1.11, py35-{2.2}
+envlist = flake8, py{27,36}-1.11, py36-{2.2,3.0,3.1}
 
 [testenv]
 commands =
     flake8: flake8 mapit mapit_gb mapit_it mapit_no mapit_se mapit_za project
-    py{27,35}: python -W all -W ignore::PendingDeprecationWarning -m coverage run --source mapit manage.py test mapit mapit_gb
+    py{27,36}: python -W all -W ignore::PendingDeprecationWarning -m coverage run --source mapit manage.py test mapit mapit_gb
 deps =
-    py{27,35}: coverage
+    py{27,36}: coverage
     flake8: flake8
     1.11: Django>=1.11,<2.0
     2.2: Django>=2.2,<3.0
+    3.0: Django>=3.0,<3.1
+    3.1: Django>=3.1,<3.2
 passenv = CFLAGS PYTHONWARNINGS
 setenv =
-    py35: DYLD_FALLBACK_LIBRARY_PATH=/opt/local/lib:/usr/lib
     PYTHONDONTWRITEBYTECODE=1
 
 [testenv:flake8]
@@ -21,10 +22,12 @@ skip_install = True
 [gh-actions]
 python =
     2.7: flake8, py27
-    3.5: flake8, py35
+    3.6: flake8, py36
 
 [gh-actions:env]
 THING_TO_TEST =
   flake8: flake8
   1.11: 1.11
   2.2: 2.2
+  3.0: 3.0
+  3.1: 3.1


### PR DESCRIPTION
Minimum python 3 is 3.6 for 3.0.

We need to stop using vendored six, as that has been removed, and the
URL dispatcher has changed so it no longer passes in non-matching parts
(in our case, the format ending).

Hopefully that is all.
