### PR TITLE
[UK] Default blank names to the empty string.

### DIFF
--- a/mapit_gb/management/commands/mapit_UK_import_boundary_line.py
+++ b/mapit_gb/management/commands/mapit_UK_import_boundary_line.py
@@ -49,7 +49,7 @@ class Command(LabelCommand):
         ds = DataSource(filename)
         layer = ds[0]
         for feat in layer:
-            name = feat['NAME'].value
+            name = feat['NAME'].value or ''
             if not isinstance(name, six.text_type):
                 name = name.decode('iso-8859-1')
 


### PR DESCRIPTION
If you are running on a system with GDAL2.2 or higher, null entries are
now returned as null, not the empty string. Boundary-Line contains null
entries for its NCP areas, so treat those like an empty string.

Fixes #369