### PR TITLE
Improve caching of postcode endpoints

### DIFF
--- a/mapit/shortcuts.py
+++ b/mapit/shortcuts.py
@@ -66,10 +66,10 @@ def output_json(out, code=200):
         content = map(lambda x: x, content)
 
         response = http.StreamingHttpResponse(content_type='application/json', status=code)
-        response['Cache-Control'] = 'max-age=2419200'  # 4 weeks
         attr = 'streaming_content' if getattr(response, 'streaming', None) else 'content'
         setattr(response, attr, content)
 
+    response['Cache-Control'] = 'max-age=2419200'  # 4 weeks
     response['Access-Control-Allow-Origin'] = '*'
 
     return response

--- a/mapit/shortcuts.py
+++ b/mapit/shortcuts.py
@@ -54,20 +54,18 @@ def output_json(out, code=200):
 
     if type(out) is dict:
         response = http.JsonResponse(
-            out, status=code, encoder=GEOS_JSONEncoder, json_dumps_params=json_dumps_params
-        )
+            out,
+            status=code,
+            encoder=GEOS_JSONEncoder,
+            json_dumps_params=json_dumps_params)
     else:
         encoder = GEOS_JSONEncoder(**json_dumps_params)
         content = encoder.iterencode(out)
 
-        # We don't want a generator function (iterencode) to be passed to an
-        # HttpResponse, as it won't cache due to its close() function adding it to
-        # an instance attribute.
-        content = map(lambda x: x, content)
-
-        response = http.StreamingHttpResponse(content_type='application/json', status=code)
-        attr = 'streaming_content' if getattr(response, 'streaming', None) else 'content'
-        setattr(response, attr, content)
+        response = http.StreamingHttpResponse(
+            streaming_content=content,
+            content_type='application/json',
+            status=code)
 
     response['Cache-Control'] = 'max-age=2419200'  # 4 weeks
     response['Access-Control-Allow-Origin'] = '*'


### PR DESCRIPTION
This PR modifies the responses for the postcode endpoint to not use a streaming HTTP response, to allow Django to cache the responses preventing the need for subsequent expensive database queries.

Previously, the output_json method always returned a streaming HTTP response, which prevented the need to load the full response contents into memory before sending, lowering memory usage. However, this prevented Django from caching views using the output_json method. This modifies the output_method to not use a streaming response for those responses already loaded into memory (i.e. not using the iterdict) and would gain no benefit. This will allow for Django to automatically cache those views and reduce the need for expensive database queries (e.g. mainly the /postcodes endpoints).