### PR TITLE
Do not log our own ViewExceptions.

### DIFF
--- a/mapit/middleware/view_error.py
+++ b/mapit/middleware/view_error.py
@@ -30,9 +30,11 @@ class ViewExceptionMiddleware(object):
                 500: http.HttpResponseServerError,
             }
             response_type = types.get(code, http.HttpResponse)
-            return response_type(render_to_string(
+            response = response_type(render_to_string(
                 'mapit/%s.html' % code,
                 {'error': message},
                 request=request
             ))
+            response._has_been_logged = True
+            return response
         return output_json({'error': message}, code=code)


### PR DESCRIPTION
Since Django 2.1, all 500s are logged as errors, including ones manually
generated by the code. We do not want to receive logged errors for ones
we are choosing to generate, so mark the response as already logged with
the logger's internal flag.