### PR TITLE
Do not log our own JSON ViewExceptions.

### DIFF
--- a/mapit/shortcuts.py
+++ b/mapit/shortcuts.py
@@ -58,6 +58,8 @@ def output_json(out, code=200):
             status=code,
             encoder=GEOS_JSONEncoder,
             json_dumps_params=json_dumps_params)
+        if code != 200:
+            response._has_been_logged = True
     else:
         encoder = GEOS_JSONEncoder(**json_dumps_params)
         content = encoder.iterencode(out)

--- a/mapit_gb/management/commands/mapit_UK_import_osni.py
+++ b/mapit_gb/management/commands/mapit_UK_import_osni.py
@@ -244,7 +244,7 @@ class Command(BaseCommand):
         # on the geometry object
         def transform_geom(self, geom):
             geom.srid = self.srid
-            if not(self.srid == settings.MAPIT_AREA_SRID):
+            if self.srid != settings.MAPIT_AREA_SRID:
                 geom.transform(settings.MAPIT_AREA_SRID)
             return geom
 

--- a/mapit_gb/management/structural_changes.py
+++ b/mapit_gb/management/structural_changes.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
 
     def _create(self, name, typ, area, gss=None):
         if isinstance(area, Area):
-            assert(area.polygons.count() == 1)
+            assert area.polygons.count() == 1
             geom = area.polygons.get().polygon
         else:
             geom = self._union(area)


### PR DESCRIPTION
Following on from b5172f6d, make sure JSON error output is also marked as already logged, as we do not want to receive logged errors for ones we are choosing to generate.
