### PR TITLE
Add filtering and excluding by mutliple types and countries in raise generation script.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+Unreleased
+    * Development improvements:
+        * Add support for filtering / excluding areas by multiple types or countries in raise generation script.
+
 Version 3.0, 2020-11-05
     * New features:
         * Add support for Django 3.0 and 3.1. #368


### PR DESCRIPTION
Allows selecting multiple countries / types e.g. `--type "ABC" --type "DEF" --country "E" -- country "W"`.

Also allows flipping to exclude by type or country via `--type-mode "all-but" --country-mode "all-but"`.