### PR TITLE
Faster ONSPD import

### DIFF
--- a/mapit_gb/management/commands/mapit_UK_import_onspd.py
+++ b/mapit_gb/management/commands/mapit_UK_import_onspd.py
@@ -1,16 +1,30 @@
 # This script is used to import postcodes from the ONS Postcode Directory:
 # https://www.ons.gov.uk/methodology/geography/geographicalproducts/postcodeproducts
 
-from mapit.management.commands.mapit_import_postal_codes import Command
+import csv
+from django.db import connection, transaction
+from django.core.management.base import LabelCommand
+from mapit.iterables import iterable_to_stream
 
 
-class Command(Command):
+FIELD_CODE = 0
+FIELD_END_DATE = 4
+FIELD_COORD_LON = 11
+FIELD_COORD_LAT = 12
+FIELD_PQI = 13
+
+
+def strip_spaces(row):
+    row[FIELD_CODE] = row[FIELD_CODE].replace(' ', '')
+    return row
+
+
+class Command(LabelCommand):
     help = ('Imports UK postcodes from the ONSPD.\n\nBy default imports only '
             'live GB postcodes with a lat/lng, options are available to also '
             'import terminated, NI, or Crown Dependency postcodes and those '
             'without locations.')
     label = '<ONSPD CSV file>'
-    option_defaults = {'header-row': True, 'strip': True, 'srid': 27700, 'coord-field-lon': 12, 'coord-field-lat': 13}
 
     def add_arguments(self, parser):
         super(Command, self).add_arguments(parser)
@@ -38,7 +52,7 @@ class Command(Command):
             action='store',
             dest='crown-dependencies',
             default='exclude',
-            help=('How to handle crown dependency postocdes.  Set to "include" '
+            help=('How to handle crown dependency postcodes.  Set to "include" '
                   'to import them, set to "exclude" to ignore them, set to '
                   '"only" to import only these. (Default: exclude).  Note that '
                   'Crown Dependency postcodes have no location info and are '
@@ -56,26 +70,45 @@ class Command(Command):
                   ' run mapit_UK_import_onspd_ni_areas before trying to import '
                   'any NI postcodes.')
         )
-        parser.add_argument(
-            '--gb-srid',
-            action='store',
-            dest='gb-srid',
-            default=27700,
-            help=('SRID for GB & Crown Dependency postcodes. Overrides --srid '
-                  'value. (Default: 27700).')
-        )
-        parser.add_argument(
-            '--ni-srid',
-            action='store',
-            dest='ni-srid',
-            default=29902,
-            help=('SRID for NI postcodes. Overrides --srid value for. (Default:'
-                  ' 29902).')
-        )
 
     def handle_label(self, file, **options):
         self.check_options_are_valid(options)
-        self.process(file, options)
+
+        reader = csv.reader(open(file))
+        next(reader)
+
+        reader = filter(lambda row: self.pre_row(row, options), reader)
+        reader = map(strip_spaces, reader)
+        reader = map(lambda row: f'{row[FIELD_CODE]},{row[FIELD_COORD_LON]},{row[FIELD_COORD_LAT]}\n'.encode(), reader)
+        reader = iterable_to_stream(reader)
+
+        with transaction.atomic():
+            cursor = connection.cursor()
+            self.stdout.write("Creating temporary table")
+            cursor.execute('CREATE TEMPORARY TABLE mapit_postcode_new '
+                           '(postcode varchar(7), location geometry(Point, 4326), easting int, northing int) '
+                           'ON COMMIT DROP')
+            self.stdout.write("Copying in data:")
+            cursor.copy_expert('COPY mapit_postcode_new(postcode, easting, northing) '
+                               'FROM STDIN WITH (FORMAT csv)', reader)
+            self.stdout.write(f"{cursor.rowcount} rows")
+            self.stdout.write("Setting geometry column")
+            cursor.execute("UPDATE mapit_postcode_new "
+                           "SET location = ST_Transform(ST_SetSRID(ST_Point(easting, northing), 27700), 4326) "
+                           "WHERE postcode NOT LIKE 'BT%'")
+            cursor.execute("UPDATE mapit_postcode_new "
+                           "SET location = ST_Transform(ST_SetSRID(ST_Point(easting, northing), 29902), 4326) "
+                           "WHERE postcode LIKE 'BT%'")
+            self.stdout.write("Updating existing rows:")
+            cursor.execute('UPDATE mapit_postcode SET location = n.location FROM mapit_postcode_new n '
+                           'WHERE (n.location IS DISTINCT FROM mapit_postcode.location) '
+                           'AND n.postcode = mapit_postcode.postcode')
+            self.stdout.write(f"{cursor.rowcount} rows updated")
+            self.stdout.write("Adding new data:")
+            cursor.execute('INSERT INTO mapit_postcode (postcode, location) '
+                           'SELECT n.postcode, n.location FROM mapit_postcode_new n '
+                           'LEFT JOIN mapit_postcode p ON n.postcode = p.postcode WHERE p.postcode IS NULL')
+            self.stdout.write(f"{cursor.rowcount} rows created")
 
     def pre_row(self, row, options):
         if self.reject_row_based_on_termination_data(row, options):
@@ -86,11 +119,6 @@ class Command(Command):
             return False  # handle crown depenency options
         elif self.reject_row_based_on_northern_ireland_data(row, options):
             return False  # handle northern ireland options
-
-        if self.northern_ireland_postcode():
-            options['srid'] = options['ni-srid']
-        else:
-            options['srid'] = options['gb-srid']
 
         return True
 
@@ -109,13 +137,13 @@ class Command(Command):
                                 '--northern-ireland and --crown-dependencies'))
 
     def location_available_for_row(self, row):
-        return row[13] != '9'  # PO Box etc.
+        return row[FIELD_PQI] != '9'  # PO Box etc.
 
-    def crown_dependency_postcode(self):
-        return self.code[0:2] in ('GY', 'JE', 'IM')
+    def crown_dependency_postcode(self, row):
+        return row[FIELD_CODE][0:2] in ('GY', 'JE', 'IM')
 
-    def northern_ireland_postcode(self):
-        return self.code[0:2] == 'BT'
+    def northern_ireland_postcode(self, row):
+        return row[FIELD_CODE][0:2] == 'BT'
 
     def reject_row_based_on_location_data(self, row, options):
         if self.location_available_for_row(row):
@@ -126,16 +154,16 @@ class Command(Command):
             return True   # no location and not allowed, reject
 
     def reject_row_based_on_termination_data(self, row, options):
-        return row[4] and not options['include-terminated']
+        return row[FIELD_END_DATE] and not options['include-terminated']
 
     def allow_row_with_no_location(self, row, options):
         # crown dependencies have no location data in ONSPD so we allow the
         # row and defer the decision to reject the row until we examine the
         # 'crown-dependencies' option.
-        return options['include-no-location'] or self.crown_dependency_postcode()
+        return options['include-no-location'] or self.crown_dependency_postcode(row)
 
     def reject_row_based_on_crown_dependency_data(self, row, options):
-        if self.crown_dependency_postcode():
+        if self.crown_dependency_postcode(row):
             return options['crown-dependencies'] == 'exclude'  # reject if we should exclude these codes
         elif options['crown-dependencies'] == 'only':
             return True  # if we're only importing these codes, reject other codes
@@ -143,7 +171,7 @@ class Command(Command):
             return False  # otherwise keep
 
     def reject_row_based_on_northern_ireland_data(self, row, options):
-        if self.northern_ireland_postcode():
+        if self.northern_ireland_postcode(row):
             return options['northern-ireland'] == 'exclude'  # reject if we should exclude these codes
         elif options['northern-ireland'] == 'only':
             return True  # if we're only importing these codes, reject other codes


### PR DESCRIPTION
This switches from the default loop/check/save to postgres copy into a temporary table and update/insert based on differences. The first run compared to previous way will have a lot of minute updates due to the location calculation being slightly different (going from CSV E/N -> 4326 in DB rather than code), but in the order of millimetres(!). Import time goes from 12 hours to a few minutes.