### PR TITLE
Fix MapIt install script

### DIFF
--- a/bin/site-specific-install.sh
+++ b/bin/site-specific-install.sh
@@ -23,7 +23,7 @@ misuse() {
 [ -z "$DISTRIBUTION" ] && misuse DISTRIBUTION
 [ -z "$DISTVERSION" ] && misuse DISTVERSION
 
-apt-get install -qq -y gunicorn g++ python3-venv >/dev/null
+apt-get install -qq -y g++ python3-venv >/dev/null
 
 install_nginx
 
@@ -54,6 +54,9 @@ if [ $POSTGIS_TWO = Yes ]
 then
     su -l -c "psql -c 'ALTER USER $UNIX_USER WITH NOSUPERUSER'" postgres
 fi
+
+# Install gunicorn within the virtual environment
+su -l -c "source $DIRECTORY/virtualenv-mapit/bin/activate && pip install gunicorn==21.0.1" "$UNIX_USER"
 
 install_sysvinit_script
 

--- a/bin/site-specific-install.sh
+++ b/bin/site-specific-install.sh
@@ -23,7 +23,7 @@ misuse() {
 [ -z "$DISTRIBUTION" ] && misuse DISTRIBUTION
 [ -z "$DISTVERSION" ] && misuse DISTVERSION
 
-apt-get install -qq -y python-flup gunicorn >/dev/null
+apt-get install -qq -y gunicorn >/dev/null
 
 install_nginx
 

--- a/bin/site-specific-install.sh
+++ b/bin/site-specific-install.sh
@@ -23,7 +23,7 @@ misuse() {
 [ -z "$DISTRIBUTION" ] && misuse DISTRIBUTION
 [ -z "$DISTVERSION" ] && misuse DISTVERSION
 
-apt-get install -qq -y gunicorn >/dev/null
+apt-get install -qq -y gunicorn g++ >/dev/null
 
 install_nginx
 

--- a/bin/site-specific-install.sh
+++ b/bin/site-specific-install.sh
@@ -23,7 +23,7 @@ misuse() {
 [ -z "$DISTRIBUTION" ] && misuse DISTRIBUTION
 [ -z "$DISTVERSION" ] && misuse DISTVERSION
 
-apt-get install -qq -y gunicorn g++ >/dev/null
+apt-get install -qq -y gunicorn g++ python3-venv >/dev/null
 
 install_nginx
 

--- a/conf/sysvinit.example
+++ b/conf/sysvinit.example
@@ -21,7 +21,7 @@ test -f $DAEMON || exit 0
 set -e
 
 start_daemon() {
-  cd $SITE_HOME/mapit && ../virtualenv-mapit/bin/python /usr/bin/gunicorn project.wsgi:application \
+  cd $SITE_HOME/mapit && ../virtualenv-mapit/bin/python ../virtualenv-mapit/bin/gunicorn project.wsgi:application \
                                      --user=$USER \
                                      --group=$USER \
                                      -D \


### PR DESCRIPTION
This PR attempts to fix the automated installation script for MapIt on more recent versions of Ubuntu (but not Jammy, 22.04) and Debian Linux.

I have confirmed the installation succeeds on clean installs of Ubuntu Focal (20.04) and Debian Bullseye (11) on Amazon EC2 instances at the default hostname, and tested subsequent loading of boundary data works on Debian Bullseye.

It **does not appear to work automatically on Ubuntu Jammy (22.04)** because of changes in `apt-get install` behaviour, I think related to the [`needrestart`](https://askubuntu.com/questions/1367139/apt-get-upgrade-auto-restart-services) command, but I haven't had time to investigate this properly.

To use this version of the install script, you can use the override behaviour in the `install-site.sh` script. Run the following commands:

```
curl -O https://raw.githubusercontent.com/mysociety/commonlib/master/bin/install-site.sh
chmod u+x install-site.sh
export REPOSITORY_URL_OVERRIDE=https://github.com/mikejamesthompson/mapit
export BRANCH_OVERRIDE=fix-install-script
sudo --preserve-env ./install-site.sh --default mapit mapit
```

Changes are explained in commit messages.

