### PR TITLE
Use standard area_from_code for legacy code lookup

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        thing-to-test: [flake8, 3.2, 4.1]
+        thing-to-test: [flake8, 3.2, 4.2]
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py39-{3.2,4.1}
+envlist = flake8, py39-{3.2,4.2}
 
 [testenv]
 commands =
@@ -9,7 +9,7 @@ deps =
     py39: coverage
     flake8: flake8
     3.2: Django>=3.2,<4.0
-    4.1: Django>=4.1,<4.2
+    4.2: Django>=4.2,<5.0
 passenv =
     CFLAGS
     PYTHONWARNINGS
@@ -27,4 +27,4 @@ python =
 THING_TO_TEST =
   flake8: flake8
   3.2: 3.2
-  4.1: 4.1
+  4.2: 4.2


### PR DESCRIPTION
This should mean no unhandled server errors if multiple results returned, and both endpoints should act the same (so the /code lookup will now pass through a query string, and the legacy /area lookup should cope better with multiple results, and you could now include a type to differentiate between WMC/WMCF).