### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/mapit/add_areas_from_file/core.py
+++ b/mapit/add_areas_from_file/core.py
@@ -78,7 +78,7 @@ class Parameters:
             return (
                 "You can only specify one of 'name field' or 'override name'."
             )
-        elif not self.name_field and not self.override_name:
+        if not self.name_field and not self.override_name:
             return "One of 'name field' or 'override name' must be specified."
 
         if self.code_field and self.override_code:

--- a/mapit/geometryserialiser.py
+++ b/mapit/geometryserialiser.py
@@ -106,14 +106,11 @@ class GeometrySerialiser(object):
                 output += self.kml_placemark % (escape(area[1].name), area[0].ogr.kml)
             output += self.kml_footer
             return (output, content_type)
-        elif kml_type == "polygon":
+        if kml_type == "polygon":
             if len(processed_areas) == 1:
                 return (processed_areas[0][0].ogr.kml, content_type)
-            else:
-                raise Exception("kml_type: '%s' not supported for multiple areas"
-                                % (kml_type,))
-        else:
-            raise Exception("Unknown kml_type: '%s'" % (kml_type,))
+            raise Exception("kml_type: '%s' not supported for multiple areas" % (kml_type,))
+        raise Exception("Unknown kml_type: '%s'" % (kml_type,))
 
     # output self.areas as geojson
     def geojson(self):
@@ -121,15 +118,14 @@ class GeometrySerialiser(object):
         processed_areas = self.__process_polygons()
         if len(processed_areas) == 1 and self.single:
             return (processed_areas[0][0].ogr.json, content_type)
-        else:
-            output = {
-                'type': 'FeatureCollection',
-                'features': [
-                    self.area_as_geojson_feature(area[1], area[0])
-                    for area in processed_areas
-                ]
-            }
-            return (json.dumps(output), content_type)
+        output = {
+            'type': 'FeatureCollection',
+            'features': [
+                self.area_as_geojson_feature(area[1], area[0])
+                for area in processed_areas
+            ]
+        }
+        return (json.dumps(output), content_type)
 
     def area_as_geojson_feature(self, area, polygons):
         return {
@@ -144,5 +140,4 @@ class GeometrySerialiser(object):
         processed_areas = self.__process_polygons()
         if len(processed_areas) == 1:
             return (processed_areas[0][0].wkt, content_type)
-        else:
-            raise Exception("wkt not supported for multiple areas")
+        raise Exception("wkt not supported for multiple areas")

--- a/mapit/management/command_utils.py
+++ b/mapit/management/command_utils.py
@@ -349,10 +349,9 @@ def fix_invalid_geos_geometry(geos_geometry):
     """
     if geos_geometry.geom_type == 'Polygon':
         return fix_invalid_geos_polygon(geos_geometry)
-    elif geos_geometry.geom_type == 'MultiPolygon':
+    if geos_geometry.geom_type == 'MultiPolygon':
         return fix_invalid_geos_multipolygon(geos_geometry)
-    else:
-        raise Exception("Don't know how to fix an invalid %s" % geos_geometry.geom_type)
+    raise Exception("Don't know how to fix an invalid %s" % geos_geometry.geom_type)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.