### PR TITLE
Return JSON for 404s, matching the rest of the API

### DIFF
--- a/mapit/shortcuts.py
+++ b/mapit/shortcuts.py
@@ -101,7 +101,7 @@ def json_500(request):
     return output_json({'error': "Sorry, something's gone wrong."}, code=500)
 
 
-def json_404(request, exception=None):
+def json_404(request, *args, **kwargs):
     return output_json({'error': "Not found."}, code=404)
 
 

--- a/mapit/shortcuts.py
+++ b/mapit/shortcuts.py
@@ -101,6 +101,10 @@ def json_500(request):
     return output_json({'error': "Sorry, something's gone wrong."}, code=500)
 
 
+def json_404(request, exception=None):
+    return output_json({'error': "Not found."}, code=404)
+
+
 def set_timeout(format):
     cursor = connection.cursor()
     timeout = 10000 if format == 'html' else 10000

--- a/mapit/urls.py
+++ b/mapit/urls.py
@@ -2,6 +2,7 @@ from django.urls import include, re_path
 from django.conf import settings
 from django.shortcuts import render
 
+from mapit.shortcuts import json_404
 from mapit.utils import re_number as number
 from mapit.views import areas, postcodes
 
@@ -58,6 +59,12 @@ urlpatterns = [
     re_path(r'^areas/(?P<name>.+?)%s$' % map_format_end, areas.areas_by_name),
     re_path(r'^areas$', areas.deal_with_POST, {'call': 'areas'}),
     re_path(r'^code/(?P<code_type>[^/]+)/(?P<code_value>[^/]+?)%s$' % format_end, areas.area_from_code),
+
+    # Catch API-shaped URLs that didn't match any of the specific patterns
+    # above and return a JSON 404 instead of Django's HTML one. Non-API URLs
+    # still fall through to the project-level 404 page.
+    re_path(r'^(?:postcode|area|areas|point|nearest|code)(?:/.*|\.[a-z]+)?$', json_404),
+    re_path(r'^(?:generations|types)(?:\.[a-z]+)?$', json_404),
 ]
 
 # Include app-specific urls

--- a/project/urls.py
+++ b/project/urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 from django.contrib import admin
 
+handler404 = 'mapit.shortcuts.json_404'
 handler500 = 'mapit.shortcuts.json_500'
 
 urlpatterns = [

--- a/project/urls.py
+++ b/project/urls.py
@@ -1,7 +1,6 @@
 from django.urls import include, path
 from django.contrib import admin
 
-handler404 = 'mapit.shortcuts.json_404'
 handler500 = 'mapit.shortcuts.json_500'
 
 urlpatterns = [


### PR DESCRIPTION
Per #421 and @dracos' comment there, hitting a URL the router doesn't recognise currently falls through to Django's HTML 404 page even though the docs say the API always returns JSON. `handler500` is already wired up to `mapit.shortcuts.json_500`; just mirror the pattern with a `json_404` and register it as `handler404`.

`get_object_or_404` still goes through `ViewException` so endpoint-level 404s are unchanged.

Closes #421.