### PR TITLE
Surface decode errors when reading feature names during import

### DIFF
--- a/mapit/add_areas_from_file/core.py
+++ b/mapit/add_areas_from_file/core.py
@@ -182,8 +182,15 @@ def run(filename, parameters, logger=None):
                 try:
                     name = feat[nf].value
                     break
-                except:
+                except IndexError:
+                    # No field by that name on this feature, try the next one.
                     pass
+                except UnicodeDecodeError:
+                    raise Error(
+                        "Could not decode name using encoding '%s' - is it in"
+                        " another encoding?"
+                        % parameters.encoding
+                    )
             if name is None and not parameters.ignore_blank:
                 choices = ", ".join(layer.fields)
                 raise Error(


### PR DESCRIPTION
Fixes #168.

When the loop pulling a feature's name out of `feat[nf].value` hit a `UnicodeDecodeError` (Django GDAL calls `force_text` inside the field accessor), the bare `except` was swallowing it and the user got 'Could not find name using name field ...' instead, which is misleading and sends them off looking for the wrong problem.

Narrowed to `IndexError` for the genuine missing-field case (which is what the loop's actually trying to handle, so it can try the next `name_field` alternative). `UnicodeDecodeError` now re-raises with the existing 'Could not decode name using encoding ...' message.