### PR TITLE
GEOS_JSONEncoder: catch AttributeError, not anything

### DIFF
--- a/mapit/shortcuts.py
+++ b/mapit/shortcuts.py
@@ -17,7 +17,7 @@ class GEOS_JSONEncoder(DjangoJSONEncoder):
     def default(self, o):
         try:
             return o.json  # Will therefore support all the GEOS objects
-        except:
+        except AttributeError:
             pass
         return super(GEOS_JSONEncoder, self).default(o)
 


### PR DESCRIPTION
The encoder's `default()` probes for an `o.json` attribute and falls back to the parent class when it isn't there. A bare except also swallows the parent's `TypeError` for an unencodable type, which is what we'd actually want to surface.